### PR TITLE
List currently attached partitions / cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 ARG CONTAINER_RUBY_VERSION=2.2.2
 FROM ruby:$CONTAINER_RUBY_VERSION
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main 10" >> /etc/apt/sources.list.d/pgdg.list \
-  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && apt-get update \
-  && apt-get install -qq -y --fix-missing --no-install-recommends \
-       build-essential \
-       less \
-       libpq-dev \
-       postgresql-client-10 \
-  && rm -rf /var/lib/apt/lists/*
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main 10" >> /etc/apt/sources.list.d/pgdg.list && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -qq -y --fix-missing --no-install-recommends \
+      less \
+      postgresql-client-10 && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundler -v 1.15.2
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [circle]:   https://circleci.com/gh/rkrage/pg_party
 [climate]:  https://codeclimate.com/github/rkrage/pg_party
 
-[Active Record](http://guides.rubyonrails.org/active_record_basics.html) migrations and model helpers for creating and managing [PostgreSQL 10 partitions](https://www.postgresql.org/docs/10/static/ddl-partitioning.html)!
+[ActiveRecord](http://guides.rubyonrails.org/active_record_basics.html) migrations and model helpers for creating and managing [PostgreSQL 10 partitions](https://www.postgresql.org/docs/10/static/ddl-partitioning.html)!
 
 Features:
   - migration methods for partition specific database operations
@@ -98,7 +98,7 @@ Attach an existing table to a range partition:
 ```ruby
 class AttachRangePartition < ActiveRecord::Migration[5.1]
   def up
-    attach_range_partition("parent_table", "child_table")
+    attach_range_partition(:parent_table, :child_table)
   end
 end
 ```
@@ -108,7 +108,7 @@ Attach an existing table to a list partition:
 ```ruby
 class AttachListPartition < ActiveRecord::Migration[5.1]
   def up
-    attach_list_partition("parent_table", "child_table")
+    attach_list_partition(:parent_table, :child_table)
   end
 end
 ```
@@ -118,7 +118,7 @@ Detach a child table from any partition:
 ```ruby
 class DetachPartition < ActiveRecord::Migration[5.1]
   def up
-    detach_partition("parent_table", "child_table")
+    detach_partition(:parent_table, :child_table)
   end
 end
 ```
@@ -179,10 +179,10 @@ Query for records by partition name:
 
 ```ruby
 # returns a collection of anonymous ActiveRecord::Base subclassed instances
-SomeRangeRecord.in_partition("some_range_records_partition_name")
+SomeRangeRecord.in_partition(:some_range_records_partition_name)
 
 # returns a collection of anonymous ActiveRecord::Base subclassed instances
-SomeListRecord.in_partition("some_list_records_partition_name")
+SomeListRecord.in_partition(:some_list_records_partition_name)
 ```
 
 ## Development
@@ -200,7 +200,7 @@ Install dependencies:
 
 Run the tests:
 
-    $ bin/de rake
+    $ bin/de appraisal rake
 
 Open a Pry console to play around with the sample Rails app:
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Features:
   - model methods for querying partitioned data
   - model methods for creating adhoc partitions
 
-Note: PostgreSQL 10 is currently in beta. This gem should not be used in production environments (yet).
-
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/pg_party/model/list_methods.rb
+++ b/lib/pg_party/model/list_methods.rb
@@ -1,11 +1,8 @@
 require "pg_party/model_decorator"
-require "pg_party/model/shared_methods"
 
 module PgParty
   module Model
     module ListMethods
-      include SharedMethods
-
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_list_partition(*args)
       end

--- a/lib/pg_party/model/list_methods.rb
+++ b/lib/pg_party/model/list_methods.rb
@@ -1,26 +1,17 @@
 require "pg_party/model_decorator"
+require "pg_party/model/shared_methods"
 
 module PgParty
   module Model
     module ListMethods
-      def partitions
-        PgParty::ModelDecorator.new(self).partitions
-      end
+      include SharedMethods
 
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_list_partition(*args)
       end
 
-      def in_partition(*args)
-        PgParty::ModelDecorator.new(self).in_partition(*args)
-      end
-
       def partition_key_in(*args)
         PgParty::ModelDecorator.new(self).list_partition_key_in(*args)
-      end
-
-      def partition_key_eq(*args)
-        PgParty::ModelDecorator.new(self).partition_key_eq(*args)
       end
     end
   end

--- a/lib/pg_party/model/list_methods.rb
+++ b/lib/pg_party/model/list_methods.rb
@@ -3,6 +3,10 @@ require "pg_party/model_decorator"
 module PgParty
   module Model
     module ListMethods
+      def partitions
+        PgParty::ModelDecorator.new(self).partitions
+      end
+
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_list_partition(*args)
       end

--- a/lib/pg_party/model/range_methods.rb
+++ b/lib/pg_party/model/range_methods.rb
@@ -1,11 +1,8 @@
 require "pg_party/model_decorator"
-require "pg_party/model/shared_methods"
 
 module PgParty
   module Model
     module RangeMethods
-      include SharedMethods
-
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_range_partition(*args)
       end

--- a/lib/pg_party/model/range_methods.rb
+++ b/lib/pg_party/model/range_methods.rb
@@ -1,26 +1,17 @@
 require "pg_party/model_decorator"
+require "pg_party/model/shared_methods"
 
 module PgParty
   module Model
     module RangeMethods
-      def partitions
-        PgParty::ModelDecorator.new(self).partitions
-      end
+      include SharedMethods
 
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_range_partition(*args)
       end
 
-      def in_partition(*args)
-        PgParty::ModelDecorator.new(self).in_partition(*args)
-      end
-
       def partition_key_in(*args)
         PgParty::ModelDecorator.new(self).range_partition_key_in(*args)
-      end
-
-      def partition_key_eq(*args)
-        PgParty::ModelDecorator.new(self).partition_key_eq(*args)
       end
     end
   end

--- a/lib/pg_party/model/range_methods.rb
+++ b/lib/pg_party/model/range_methods.rb
@@ -3,6 +3,10 @@ require "pg_party/model_decorator"
 module PgParty
   module Model
     module RangeMethods
+      def partitions
+        PgParty::ModelDecorator.new(self).partitions
+      end
+
       def create_partition(*args)
         PgParty::ModelDecorator.new(self).create_range_partition(*args)
       end

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -1,3 +1,5 @@
+require "pg_party/model_decorator"
+
 module PgParty
   module Model
     module SharedMethods

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -1,0 +1,25 @@
+module PgParty
+  module Model
+    module SharedMethods
+      def partitions
+        PgParty::ModelDecorator.new(self).partitions
+      end
+
+      def create_partition(*args)
+        PgParty::ModelDecorator.new(self).create_list_partition(*args)
+      end
+
+      def in_partition(*args)
+        PgParty::ModelDecorator.new(self).in_partition(*args)
+      end
+
+      def partition_key_in(*args)
+        PgParty::ModelDecorator.new(self).list_partition_key_in(*args)
+      end
+
+      def partition_key_eq(*args)
+        PgParty::ModelDecorator.new(self).partition_key_eq(*args)
+      end
+    end
+  end
+end

--- a/lib/pg_party/model_decorator.rb
+++ b/lib/pg_party/model_decorator.rb
@@ -53,7 +53,7 @@ module PgParty
 
     def get_partitions
       connection.select_values(<<-SQL)
-        SELECT pg_inherits.inhrelid::regclass
+        SELECT pg_inherits.inhrelid::regclass::text
         FROM pg_tables
         INNER JOIN pg_inherits
           ON pg_tables.tablename::regclass = pg_inherits.inhparent::regclass

--- a/lib/pg_party/model_injector.rb
+++ b/lib/pg_party/model_injector.rb
@@ -25,6 +25,7 @@ module PgParty
 
     def create_class_attributes
       @model.class_attribute(
+        :cached_partitions,
         :partition_key,
         :partition_column,
         :partition_cast,

--- a/lib/pg_party/model_injector.rb
+++ b/lib/pg_party/model_injector.rb
@@ -8,20 +8,25 @@ module PgParty
     end
 
     def inject_range_methods
-      create_class_attributes
-
       require "pg_party/model/range_methods"
-      @model.extend(PgParty::Model::RangeMethods)
+      inject_methods_for(PgParty::Model::RangeMethods)
     end
 
     def inject_list_methods
-      create_class_attributes
-
       require "pg_party/model/list_methods"
-      @model.extend(PgParty::Model::ListMethods)
+      inject_methods_for(PgParty::Model::ListMethods)
     end
 
     private
+
+    def inject_methods_for(mod)
+      require "pg_party/model/shared_methods"
+
+      @model.extend(PgParty::Model::SharedMethods)
+      @model.extend(mod)
+
+      create_class_attributes
+    end
 
     def create_class_attributes
       @model.class_attribute(

--- a/spec/integration/model/bigint_boolean_list_spec.rb
+++ b/spec/integration/model/bigint_boolean_list_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe BigintBooleanList do
   let(:connection) { described_class.connection }
+  let(:table_name) { described_class.table_name }
 
   describe ".create" do
     let(:some_bool) { true }
@@ -12,6 +13,12 @@ RSpec.describe BigintBooleanList do
       its(:id) { is_expected.to be_an(Integer) }
       its(:some_bool) { is_expected.to eq(some_bool) }
     end
+  end
+
+  describe ".partitions" do
+    subject { described_class.partitions }
+
+    it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_b") }
   end
 
   describe ".create_partition" do
@@ -27,7 +34,7 @@ RSpec.describe BigintBooleanList do
   end
 
   describe ".in_partition" do
-    let(:child_table_name) { "#{described_class.table_name}_a" }
+    let(:child_table_name) { "#{table_name}_a" }
 
     let!(:record_one) { described_class.create(some_bool: true) }
     let!(:record_two) { described_class.create(some_bool: true) }

--- a/spec/integration/model/uuid_string_list_spec.rb
+++ b/spec/integration/model/uuid_string_list_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe UuidStringList do
   let(:connection) { described_class.connection }
+  let(:table_name) { described_class.table_name }
 
   describe ".create" do
     let(:some_string) { "a" }
@@ -22,16 +23,33 @@ RSpec.describe UuidStringList do
     end
   end
 
+  describe ".partitions" do
+    subject { described_class.partitions }
+
+    it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_b") }
+  end
+
   describe ".create_partition" do
     let(:values) { ["e", "f"] }
-    let(:child_table_name) { subject }
+    let(:child_table_name) { "#{table_name}_c" }
 
-    subject { described_class.create_partition(values: values) }
+    subject { described_class.create_partition(values: values, name: child_table_name) }
 
     context "when values do not overlap" do
+      before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to include("uuid_string_lists_") }
+      it { is_expected.to eq(child_table_name) }
+
+      it "resets partition list" do
+        subject
+
+        expect(described_class.partitions).to contain_exactly(
+          "#{table_name}_a",
+          "#{table_name}_b",
+          "#{table_name}_c"
+        )
+      end
     end
 
     context "when values overlap" do

--- a/spec/integration/model/uuid_string_range_spec.rb
+++ b/spec/integration/model/uuid_string_range_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe UuidStringRange do
   let(:connection) { described_class.connection }
+  let(:table_name) { described_class.table_name }
 
   describe ".create" do
     let(:some_string) { "c" }
@@ -22,17 +23,40 @@ RSpec.describe UuidStringRange do
     end
   end
 
+  describe ".partitions" do
+    subject { described_class.partitions }
+
+    it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_b") }
+  end
+
   describe ".create_partition" do
     let(:start_range) { "0" }
     let(:end_range) { "9" }
-    let(:child_table_name) { subject }
+    let(:child_table_name) { "#{table_name}_c" }
 
-    subject { described_class.create_partition(start_range: start_range, end_range: end_range) }
+    subject do
+      described_class.create_partition(
+        start_range: start_range,
+        end_range: end_range,
+        name: child_table_name
+      )
+    end
 
     context "when ranges do not overlap" do
+      before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to include("uuid_string_ranges_") }
+      it { is_expected.to eq(child_table_name) }
+
+      it "resets partition list" do
+        subject
+
+        expect(described_class.partitions).to contain_exactly(
+          "#{table_name}_a",
+          "#{table_name}_b",
+          "#{table_name}_c"
+        )
+      end
     end
 
     context "when ranges overlap" do

--- a/spec/model/list_methods_spec.rb
+++ b/spec/model/list_methods_spec.rb
@@ -1,66 +1,15 @@
 require "spec_helper"
 
 RSpec.describe PgParty::Model::ListMethods do
-  let(:key) { "created_at::date" }
   let(:decorator) { instance_double(PgParty::ModelDecorator) }
 
   before do
-    model.list_partition_by(key)
     allow(PgParty::ModelDecorator).to receive(:new).with(model).and_return(decorator)
   end
 
   subject(:model) do
     Class.new do
-      extend PgParty::Model::Methods
-    end
-  end
-
-  describe ".partition_key" do
-    subject { model.partition_key }
-
-    it { is_expected.to eq("created_at::date") }
-  end
-
-  describe ".partition_column" do
-    subject { model.partition_column }
-
-    context "when key has cast" do
-      it { is_expected.to eq("created_at") }
-    end
-
-    context "when key does not have cast" do
-      let(:key) { "created_at" }
-
-      it { is_expected.to eq("created_at") }
-    end
-  end
-
-  describe ".partition_cast" do
-    subject { model.partition_cast }
-
-    context "when key has cast" do
-      it { is_expected.to eq("date") }
-    end
-
-    context "when key does not have cast" do
-      let(:key) { "created_at" }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe ".cached_partitions" do
-    subject { model.cached_partitions }
-
-    it { is_expected.to be_nil }
-  end
-
-  describe ".partitions" do
-    subject { model.partitions }
-
-    it "delegates to decorator" do
-      expect(decorator).to receive(:partitions)
-      subject
+      extend PgParty::Model::ListMethods
     end
   end
 
@@ -87,17 +36,6 @@ RSpec.describe PgParty::Model::ListMethods do
 
     it "delegates to decorator" do
       expect(decorator).to receive(:list_partition_key_in).with(values)
-      subject
-    end
-  end
-
-  describe ".partition_key_eq" do
-    let(:value) { Date.current }
-
-    subject { model.partition_key_eq(value) }
-
-    it "delegates to decorator" do
-      expect(decorator).to receive(:partition_key_eq).with(value)
       subject
     end
   end

--- a/spec/model/list_methods_spec.rb
+++ b/spec/model/list_methods_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe PgParty::Model::ListMethods do
     end
   end
 
+  describe ".cached_partitions" do
+    subject { model.cached_partitions }
+
+    it { is_expected.to be_nil }
+  end
+
+  describe ".partitions" do
+    subject { model.partitions }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partitions)
+      subject
+    end
+  end
+
   describe ".create_partition" do
     let(:args) do
       {

--- a/spec/model/range_methods_spec.rb
+++ b/spec/model/range_methods_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe PgParty::Model::RangeMethods do
     end
   end
 
+  describe ".cached_partitions" do
+    subject { model.cached_partitions }
+
+    it { is_expected.to be_nil }
+  end
+
+  describe ".partitions" do
+    subject { model.partitions }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partitions)
+      subject
+    end
+  end
+
   describe ".create_partition" do
     let(:args) do
       {

--- a/spec/model/range_methods_spec.rb
+++ b/spec/model/range_methods_spec.rb
@@ -1,66 +1,15 @@
 require "spec_helper"
 
 RSpec.describe PgParty::Model::RangeMethods do
-  let(:key) { "created_at::date" }
   let(:decorator) { instance_double(PgParty::ModelDecorator) }
 
   before do
-    model.range_partition_by(key)
     allow(PgParty::ModelDecorator).to receive(:new).with(model).and_return(decorator)
   end
 
   subject(:model) do
     Class.new do
-      extend PgParty::Model::Methods
-    end
-  end
-
-  describe ".partition_key" do
-    subject { model.partition_key }
-
-    it { is_expected.to eq("created_at::date") }
-  end
-
-  describe ".partition_column" do
-    subject { model.partition_column }
-
-    context "when key has cast" do
-      it { is_expected.to eq("created_at") }
-    end
-
-    context "when key does not have cast" do
-      let(:key) { "created_at" }
-
-      it { is_expected.to eq("created_at") }
-    end
-  end
-
-  describe ".partition_cast" do
-    subject { model.partition_cast }
-
-    context "when key has cast" do
-      it { is_expected.to eq("date") }
-    end
-
-    context "when key does not have cast" do
-      let(:key) { "created_at" }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe ".cached_partitions" do
-    subject { model.cached_partitions }
-
-    it { is_expected.to be_nil }
-  end
-
-  describe ".partitions" do
-    subject { model.partitions }
-
-    it "delegates to decorator" do
-      expect(decorator).to receive(:partitions)
-      subject
+      extend PgParty::Model::RangeMethods
     end
   end
 
@@ -89,17 +38,6 @@ RSpec.describe PgParty::Model::RangeMethods do
 
     it "delegates to decorator" do
       expect(decorator).to receive(:range_partition_key_in).with(start_range, end_range)
-      subject
-    end
-  end
-
-  describe ".partition_key_eq" do
-    let(:value) { Date.current }
-
-    subject { model.partition_key_eq(value) }
-
-    it "delegates to decorator" do
-      expect(decorator).to receive(:partition_key_eq).with(value)
       subject
     end
   end

--- a/spec/model/shared_methods_spec.rb
+++ b/spec/model/shared_methods_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe PgParty::Model::SharedMethods do
+  let(:decorator) { instance_double(PgParty::ModelDecorator) }
+
+  before do
+    allow(PgParty::ModelDecorator).to receive(:new).with(model).and_return(decorator)
+  end
+
+  subject(:model) do
+    Class.new do
+      extend PgParty::Model::SharedMethods
+    end
+  end
+
+  describe ".partitions" do
+    subject { model.partitions }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partitions)
+      subject
+    end
+  end
+
+  describe ".partition_key_eq" do
+    let(:value) { Date.current }
+
+    subject { model.partition_key_eq(value) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partition_key_eq).with(value)
+      subject
+    end
+  end
+end

--- a/spec/model_injector_spec.rb
+++ b/spec/model_injector_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe PgParty::ModelInjector do
       its(:partition_key) { is_expected.to eq("created_at::date") }
       its(:partition_column) { is_expected.to eq("created_at") }
       its(:partition_cast) { is_expected.to eq("date") }
+      its(:cached_partitions) { is_expected.to be_nil }
     end
   end
 
@@ -47,6 +48,7 @@ RSpec.describe PgParty::ModelInjector do
       its(:partition_key) { is_expected.to eq("created_at::date") }
       its(:partition_column) { is_expected.to eq("created_at") }
       its(:partition_cast) { is_expected.to eq("date") }
+      its(:cached_partitions) { is_expected.to be_nil }
     end
   end
 end

--- a/spec/model_injector_spec.rb
+++ b/spec/model_injector_spec.rb
@@ -8,13 +8,18 @@ RSpec.describe PgParty::ModelInjector do
   subject(:inject_range_methods) { injector.inject_range_methods }
   subject(:inject_list_methods) { injector.inject_list_methods }
 
-  before { allow(model).to receive(:extend) }
+  before { allow(model).to receive(:extend).and_call_original }
 
   describe "#inject_range_methods" do
     subject { inject_range_methods }
 
     it "extends range methods" do
       expect(model).to receive(:extend).with(PgParty::Model::RangeMethods)
+      subject
+    end
+
+    it "extends shared methods" do
+      expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
       subject
     end
 
@@ -36,6 +41,11 @@ RSpec.describe PgParty::ModelInjector do
 
     it "extends range methods" do
       expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
+      subject
+    end
+
+    it "extends shared methods" do
+      expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
       subject
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.mock_with :rspec do |c|
+    c.verify_partial_doubles = true
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Resolves #1 

Summary:
- move shared injected methods into separate module
- update readme and dockerfile to reflect the official pg 10 release
- model method that queries `pg_inherits` and `pg_tables` to find partition names
- caching mechanism to avoid constant partition lookups from the db