### PR TITLE
Cache partitions and anonymous model classes

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -48,7 +48,7 @@ module PgParty
         FOR VALUES FROM (#{quote(start_range)}) TO (#{quote(end_range)})
       SQL
 
-      PgParty::Cache.clear_partitions!
+      PgParty::Cache.clear!
     end
 
     def attach_list_partition(parent_table_name, child_table_name, values:)
@@ -58,7 +58,7 @@ module PgParty
         FOR VALUES IN (#{Array.wrap(values).map(&method(:quote)).join(",")})
       SQL
 
-      PgParty::Cache.clear_partitions!
+      PgParty::Cache.clear!
     end
 
     def detach_partition(parent_table_name, child_table_name)
@@ -67,7 +67,7 @@ module PgParty
         DETACH PARTITION #{quote_table_name(child_table_name)}
       SQL
 
-      PgParty::Cache.clear_partitions!
+      PgParty::Cache.clear!
     end
 
     private
@@ -128,7 +128,7 @@ module PgParty
         SQL
       end
 
-      PgParty::Cache.clear_partitions!
+      PgParty::Cache.clear!
 
       child_table_name
     end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -1,4 +1,5 @@
 require "digest"
+require "pg_party/cache"
 
 module PgParty
   class AdapterDecorator < SimpleDelegator
@@ -46,6 +47,8 @@ module PgParty
         ATTACH PARTITION #{quote_table_name(child_table_name)}
         FOR VALUES FROM (#{quote(start_range)}) TO (#{quote(end_range)})
       SQL
+
+      PgParty::Cache.clear_partitions!
     end
 
     def attach_list_partition(parent_table_name, child_table_name, values:)
@@ -54,6 +57,8 @@ module PgParty
         ATTACH PARTITION #{quote_table_name(child_table_name)}
         FOR VALUES IN (#{Array.wrap(values).map(&method(:quote)).join(",")})
       SQL
+
+      PgParty::Cache.clear_partitions!
     end
 
     def detach_partition(parent_table_name, child_table_name)
@@ -61,6 +66,8 @@ module PgParty
         ALTER TABLE #{quote_table_name(parent_table_name)}
         DETACH PARTITION #{quote_table_name(child_table_name)}
       SQL
+
+      PgParty::Cache.clear_partitions!
     end
 
     private
@@ -120,6 +127,8 @@ module PgParty
           USING btree ((#{quote_partition_key(partition_key)}))
         SQL
       end
+
+      PgParty::Cache.clear_partitions!
 
       child_table_name
     end

--- a/lib/pg_party/cache.rb
+++ b/lib/pg_party/cache.rb
@@ -1,0 +1,53 @@
+require "thread"
+
+module PgParty
+  class Cache
+    LOCK = Mutex.new
+
+    class << self
+      def clear!
+        LOCK.synchronize do
+          partitions.clear
+          models.clear
+        end
+
+        nil
+      end
+
+      def clear_partitions!
+        LOCK.synchronize { partitions.clear }
+
+        nil
+      end
+
+      def clear_models!
+        LOCK.synchronize { models.clear }
+
+        nil
+      end
+
+      def fetch_model(parent_table, child_table, &block)
+        LOCK.synchronize do
+          models[parent_table.to_sym][child_table.to_sym] ||= block.call
+        end
+      end
+
+      def fetch_partitions(table_name, &block)
+        LOCK.synchronize do
+          partitions[table_name.to_sym] ||= block.call
+        end
+      end
+
+      private
+
+      def partitions
+        @partitions ||= {}
+      end
+
+      def models
+        # initialize a new hash as the default value
+        @models ||= Hash.new { |h, k| h[k] = {} }
+      end
+    end
+  end
+end

--- a/lib/pg_party/cache.rb
+++ b/lib/pg_party/cache.rb
@@ -6,47 +6,29 @@ module PgParty
 
     class << self
       def clear!
-        LOCK.synchronize do
-          partitions.clear
-          models.clear
-        end
-
-        nil
-      end
-
-      def clear_partitions!
-        LOCK.synchronize { partitions.clear }
-
-        nil
-      end
-
-      def clear_models!
-        LOCK.synchronize { models.clear }
+        LOCK.synchronize { store.clear }
 
         nil
       end
 
       def fetch_model(parent_table, child_table, &block)
         LOCK.synchronize do
-          models[parent_table.to_sym][child_table.to_sym] ||= block.call
+          store[parent_table.to_sym][:models][child_table.to_sym] ||= block.call
         end
       end
 
       def fetch_partitions(table_name, &block)
         LOCK.synchronize do
-          partitions[table_name.to_sym] ||= block.call
+          store[table_name.to_sym][:partitions] ||= block.call
         end
       end
 
       private
 
-      def partitions
-        @partitions ||= {}
-      end
-
-      def models
-        # initialize a new hash as the default value
-        @models ||= Hash.new { |h, k| h[k] = {} }
+      def store
+        # automatically initialize a new hash when
+        # accessing a table name that doesn't exist
+        @store ||= Hash.new { |h, k| h[k] = { models: {}, partitions: nil } }
       end
     end
   end

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -8,9 +8,7 @@ module PgParty
       end
 
       def table_exists?
-        return @table_exists if defined?(@table_exists)
-
-        @table_exists = PgParty::ModelDecorator.new(self).partition_table_exists?
+        PgParty::ModelDecorator.new(self).partition_table_exists?
       end
 
       def partitions

--- a/spec/adapter_decorator_spec.rb
+++ b/spec/adapter_decorator_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PgParty::AdapterDecorator do
     allow(table_definition).to receive(:integer)
     allow(table_definition).to receive(:timestamps)
 
-    allow(PgParty::Cache).to receive(:clear_partitions!)
+    allow(PgParty::Cache).to receive(:clear!)
   end
 
   subject(:decorator) { described_class.new(adapter) }
@@ -413,8 +413,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -463,8 +463,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -497,8 +497,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -530,8 +530,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -590,8 +590,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -637,8 +637,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -670,8 +670,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -702,8 +702,8 @@ RSpec.describe PgParty::AdapterDecorator do
         subject
       end
 
-      it "calls clear_partitions! on cache" do
-        expect(PgParty::Cache).to receive(:clear_partitions!)
+      it "calls clear! on cache" do
+        expect(PgParty::Cache).to receive(:clear!)
         subject
       end
     end
@@ -725,8 +725,8 @@ RSpec.describe PgParty::AdapterDecorator do
       subject
     end
 
-    it "calls clear_partitions! on cache" do
-      expect(PgParty::Cache).to receive(:clear_partitions!)
+    it "calls clear! on cache" do
+      expect(PgParty::Cache).to receive(:clear!)
       subject
     end
   end
@@ -747,8 +747,8 @@ RSpec.describe PgParty::AdapterDecorator do
       subject
     end
 
-    it "calls clear_partitions! on cache" do
-      expect(PgParty::Cache).to receive(:clear_partitions!)
+    it "calls clear! on cache" do
+      expect(PgParty::Cache).to receive(:clear!)
       subject
     end
   end
@@ -768,8 +768,8 @@ RSpec.describe PgParty::AdapterDecorator do
       subject
     end
 
-    it "calls clear_partitions! on cache" do
-      expect(PgParty::Cache).to receive(:clear_partitions!)
+    it "calls clear! on cache" do
+      expect(PgParty::Cache).to receive(:clear!)
       subject
     end
   end

--- a/spec/adapter_decorator_spec.rb
+++ b/spec/adapter_decorator_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe PgParty::AdapterDecorator do
     allow(table_definition).to receive(:column)
     allow(table_definition).to receive(:integer)
     allow(table_definition).to receive(:timestamps)
+
+    allow(PgParty::Cache).to receive(:clear_partitions!)
   end
 
   subject(:decorator) { described_class.new(adapter) }
@@ -410,6 +412,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:execute).with(heredoc_matching(create_index_sql))
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
 
     context "with composite primary key" do
@@ -455,6 +462,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
 
     context "with name and primary key as partition key" do
@@ -484,6 +496,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
 
     context "without name and primary key" do
@@ -510,6 +527,11 @@ RSpec.describe PgParty::AdapterDecorator do
 
       it "does not call execute to add index" do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
+        subject
+      end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
         subject
       end
     end
@@ -567,6 +589,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:execute).with(heredoc_matching(create_index_sql))
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
 
     context "with composite primary key" do
@@ -609,6 +636,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
 
     context "with name and primary key as partition key" do
@@ -635,6 +667,11 @@ RSpec.describe PgParty::AdapterDecorator do
 
       it "does not call execute to add index" do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
+        subject
+      end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
         subject
       end
     end
@@ -664,6 +701,11 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to_not receive(:execute).with(/CREATE INDEX/)
         subject
       end
+
+      it "calls clear_partitions! on cache" do
+        expect(PgParty::Cache).to receive(:clear_partitions!)
+        subject
+      end
     end
   end
 
@@ -680,6 +722,11 @@ RSpec.describe PgParty::AdapterDecorator do
 
     it "calls execute with correct SQL" do
       expect(adapter).to receive(:execute).with(heredoc_matching(expected_sql))
+      subject
+    end
+
+    it "calls clear_partitions! on cache" do
+      expect(PgParty::Cache).to receive(:clear_partitions!)
       subject
     end
   end
@@ -699,6 +746,11 @@ RSpec.describe PgParty::AdapterDecorator do
       expect(adapter).to receive(:execute).with(heredoc_matching(expected_sql))
       subject
     end
+
+    it "calls clear_partitions! on cache" do
+      expect(PgParty::Cache).to receive(:clear_partitions!)
+      subject
+    end
   end
 
   describe "#detach_partition" do
@@ -713,6 +765,11 @@ RSpec.describe PgParty::AdapterDecorator do
 
     it "calls execute with correct SQL" do
       expect(adapter).to receive(:execute).with(heredoc_matching(expected_sql))
+      subject
+    end
+
+    it "calls clear_partitions! on cache" do
+      expect(PgParty::Cache).to receive(:clear_partitions!)
       subject
     end
   end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+
+RSpec.describe PgParty::Cache do
+  let(:block) { ->{ :new_value } }
+
+  subject(:cache) { described_class }
+  subject(:fetch_model) { cache.fetch_model(:parent, :child, &block) }
+  subject(:fetch_partitions) { cache.fetch_partitions(:parent, &block) }
+
+  around do |example|
+    cache.clear!
+    example.run
+    cache.clear!
+  end
+
+  describe ".clear!" do
+    before do
+      cache.fetch_partitions(:parent) { :old_value }
+      cache.fetch_model(:parent, :child) { :old_value }
+    end
+
+    subject { cache.clear! }
+
+    it { is_expected.to be_nil }
+
+    it "clears cached partitions" do
+      subject
+      expect(fetch_partitions).to eq(:new_value)
+    end
+
+    it "clears cached models" do
+      subject
+      expect(fetch_model).to eq(:new_value)
+    end
+  end
+
+  describe ".clear_partitions!" do
+    before do
+      cache.fetch_partitions(:parent) { :old_value }
+      cache.fetch_model(:parent, :child) { :old_value }
+    end
+
+    subject { cache.clear_partitions! }
+
+    it { is_expected.to be_nil }
+
+    it "clears cached partitions" do
+      subject
+      expect(fetch_partitions).to eq(:new_value)
+    end
+
+    it "does not clear cached models" do
+      subject
+      expect(fetch_model).to eq(:old_value)
+    end
+  end
+
+  describe ".clear_models!" do
+    before do
+      cache.fetch_partitions(:parent) { :old_value }
+      cache.fetch_model(:parent, :child) { :old_value }
+    end
+
+    subject { cache.clear_models! }
+
+    it { is_expected.to be_nil }
+
+    it "does not clear cached partitions" do
+      subject
+      expect(fetch_partitions).to eq(:old_value)
+    end
+
+    it "clears cached models" do
+      subject
+      expect(fetch_model).to eq(:new_value)
+    end
+  end
+
+  describe ".fetch_model" do
+    subject { fetch_model }
+
+    context "when key does not exist" do
+      it { is_expected.to eq(:new_value) }
+
+      it "executes block" do
+        expect(block).to receive(:call).and_call_original
+        subject
+      end
+    end
+
+    context "when key exists" do
+      before do
+        cache.fetch_model(:parent, :child) { :old_value }
+      end
+
+      it { is_expected.to eq(:old_value) }
+
+      it "does not execute block" do
+        expect(block).to_not receive(:call)
+        subject
+      end
+    end
+  end
+
+  describe ".fetch_partitions" do
+    subject { fetch_partitions }
+
+    context "when key does not exist" do
+      it { is_expected.to eq(:new_value) }
+
+      it "executes block" do
+        expect(block).to receive(:call).and_call_original
+        subject
+      end
+    end
+
+    context "when key exists" do
+      before do
+        cache.fetch_partitions(:parent) { :old_value }
+      end
+
+      it { is_expected.to eq(:old_value) }
+
+      it "does not execute block" do
+        expect(block).to_not receive(:call)
+        subject
+      end
+    end
+  end
+end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -34,48 +34,6 @@ RSpec.describe PgParty::Cache do
     end
   end
 
-  describe ".clear_partitions!" do
-    before do
-      cache.fetch_partitions(:parent) { :old_value }
-      cache.fetch_model(:parent, :child) { :old_value }
-    end
-
-    subject { cache.clear_partitions! }
-
-    it { is_expected.to be_nil }
-
-    it "clears cached partitions" do
-      subject
-      expect(fetch_partitions).to eq(:new_value)
-    end
-
-    it "does not clear cached models" do
-      subject
-      expect(fetch_model).to eq(:old_value)
-    end
-  end
-
-  describe ".clear_models!" do
-    before do
-      cache.fetch_partitions(:parent) { :old_value }
-      cache.fetch_model(:parent, :child) { :old_value }
-    end
-
-    subject { cache.clear_models! }
-
-    it { is_expected.to be_nil }
-
-    it "does not clear cached partitions" do
-      subject
-      expect(fetch_partitions).to eq(:old_value)
-    end
-
-    it "clears cached models" do
-      subject
-      expect(fetch_model).to eq(:new_value)
-    end
-  end
-
   describe ".fetch_model" do
     subject { fetch_model }
 

--- a/spec/model/shared_methods_spec.rb
+++ b/spec/model/shared_methods_spec.rb
@@ -25,26 +25,9 @@ RSpec.describe PgParty::Model::SharedMethods do
   describe ".partition_table_exists?" do
     subject { model.table_exists? }
 
-    context "when class instance variable set" do
-      before { model.instance_variable_set(:@table_exists, true) }
-
-      it { is_expected.to eq(true) }
-
-      it "does not delegate to decorator" do
-        expect(decorator).to_not receive(:partition_table_exists?)
-        subject
-      end
-    end
-
-    context "when class instance variable not set" do
-      before { allow(decorator).to receive(:partition_table_exists?).and_return(true) }
-
-      it { is_expected.to eq(true) }
-
-      it "delegates to decorator" do
-        expect(decorator).to receive(:partition_table_exists?)
-        subject
-      end
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partition_table_exists?)
+      subject
     end
   end
 

--- a/spec/model_decorator_spec.rb
+++ b/spec/model_decorator_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe PgParty::ModelDecorator do
     allow(child_class).to receive(:all)
     allow(child_class).to receive(:get_primary_key)
 
-    allow(PgParty::Cache).to receive(:fetch_model).and_wrap_original { |_, *_, &blk| blk.call }
-    allow(PgParty::Cache).to receive(:fetch_partitions).and_wrap_original { |_, *_, &blk| blk.call }
+    allow(PgParty::Cache).to receive(:fetch_model).and_wrap_original { |*_, &blk| blk.call }
+    allow(PgParty::Cache).to receive(:fetch_partitions).and_wrap_original { |*_, &blk| blk.call }
   end
 
   subject(:decorator) { described_class.new(model) }


### PR DESCRIPTION
Summary:
- Introduce `PgParty::Cache` to store partition names and anonymous model classes
- In `PgParty::ModelDecorator`, fetch values from cache to avoid redundant database queries
- Clear partition list after creating, attaching, detaching partitions

This is very similar to the Rails `SchemaCache`, which as far as I can tell, does not specifically handle cache invalidation for multi-process servers. So, we're not going to handle that here either...