### PR TITLE
Support for complex partition keys / various cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,7 @@ shared_config: &shared_config
 
     - run:
         name: Prepare and start containers
-        command: |
-          docker-compose build --build-arg CONTAINER_RUBY_VERSION=$CONTAINER_RUBY_VERSION --build-arg CONTAINER_PG_VERSION=$CONTAINER_PG_VERSION code
-          docker-compose up -d
+        command: docker-compose up -d
 
     - run:
         name: Install global gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG CONTAINER_RUBY_VERSION=2.2.2
+ARG CONTAINER_RUBY_VERSION
 FROM ruby:$CONTAINER_RUBY_VERSION
 
-ARG CONTAINER_PG_VERSION=11
+ARG CONTAINER_PG_VERSION
 
 RUN export DEBIAN_CODENAME=$(cat /etc/os-release | grep "VERSION=" | cut -d "(" -f2 | cut -d ")" -f1) && \
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $DEBIAN_CODENAME-pgdg main $CONTAINER_PG_VERSION" >> /etc/apt/sources.list.d/pgdg.list && \

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 [![Gem Version](https://badge.fury.io/rb/pg_party.svg)][rubygems]
 [![Build Status](https://circleci.com/gh/rkrage/pg_party.svg?&style=shield)][circle]
-[![Dependency Status](https://gemnasium.com/badges/github.com/rkrage/pg_party.svg)][gemnasium]
 [![Maintainability](https://api.codeclimate.com/v1/badges/c409453d2283dd440227/maintainability)][cc_maintainability]
 [![Test Coverage](https://api.codeclimate.com/v1/badges/c409453d2283dd440227/test_coverage)][cc_coverage]
 
 [rubygems]:           https://rubygems.org/gems/pg_party
 [circle]:             https://circleci.com/gh/rkrage/pg_party/tree/master
-[gemnasium]:          https://gemnasium.com/github.com/rkrage/pg_party
 [cc_maintainability]: https://codeclimate.com/github/rkrage/pg_party/maintainability
 [cc_coverage]:        https://codeclimate.com/github/rkrage/pg_party/test_coverage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
 version: "3.3"
 services:
   postgres:
-    image: postgres:${CONTAINER_PG_VERSION:-11}
+    image: postgres:${CONTAINER_PG_VERSION:-10}
   code:
-    build: .
+    build:
+      context: .
+      args:
+        - CONTAINER_PG_VERSION=${CONTAINER_PG_VERSION:-10}
+        - CONTAINER_RUBY_VERSION=${CONTAINER_RUBY_VERSION:-2.2.2}
     image: pg_party
     environment:
       - CC_TEST_REPORTER_ID

--- a/lib/pg_party.rb
+++ b/lib/pg_party.rb
@@ -8,17 +8,17 @@ ActiveSupport.on_load(:active_record) do
 
   require "pg_party/adapter/abstract_methods"
 
-  ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-    include PgParty::Adapter::AbstractMethods
-  end
-  
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.include(
+    PgParty::Adapter::AbstractMethods
+  )
+
   begin
     require "active_record/connection_adapters/postgresql_adapter"
     require "pg_party/adapter/postgresql_methods"
 
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
-      include PgParty::Adapter::PostgreSQLMethods
-    end
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.include(
+      PgParty::Adapter::PostgreSQLMethods
+    )
   rescue LoadError
     # migration methods will not be available
   end

--- a/lib/pg_party/adapter/abstract_methods.rb
+++ b/lib/pg_party/adapter/abstract_methods.rb
@@ -2,31 +2,31 @@ module PgParty
   module Adapter
     module AbstractMethods
       def create_range_partition(*)
-        raise NotImplementedError, "#create_range_partition is not implemented"
+        raise "#create_range_partition is not implemented"
       end
 
       def create_list_partition(*)
-        raise NotImplementedError, "#create_list_partition is not implemented"
+        raise "#create_list_partition is not implemented"
       end
 
       def create_range_partition_of(*)
-        raise NotImplementedError, "#create_range_partition_of is not implemented"
+        raise "#create_range_partition_of is not implemented"
       end
 
       def create_list_partition_of(*)
-        raise NotImplementedError, "#create_list_partition_of is not implemented"
+        raise "#create_list_partition_of is not implemented"
       end
 
       def attach_range_partition(*)
-        raise NotImplementedError, "#attach_range_partition is not implemented"
+        raise "#attach_range_partition is not implemented"
       end
 
       def attach_list_partition(*)
-        raise NotImplementedError, "#attach_list_partition is not implemented"
+        raise "#attach_list_partition is not implemented"
       end
 
       def detach_partition(*)
-        raise NotImplementedError, "#detach_partition is not implemented"
+        raise "#detach_partition is not implemented"
       end
     end
   end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -24,7 +24,7 @@ module PgParty
         child_table_name = hashed_table_name(table_name, "#{start_range}#{end_range}")
       end
 
-      constraint_clause = "FROM #{quote_range_constraint(start_range)} TO #{quote_range_constraint(end_range)}"
+      constraint_clause = "FROM (#{quote_collection(start_range)}) TO (#{quote_collection(end_range)})"
 
       create_partition_of(table_name, child_table_name, constraint_clause, **options)
     end
@@ -36,7 +36,7 @@ module PgParty
         child_table_name = hashed_table_name(table_name, values.to_s)
       end
 
-      constraint_clause = "IN (#{Array.wrap(values).map(&method(:quote_list_constraint)).join(",")})"
+      constraint_clause = "IN (#{quote_collection(values)})"
 
       create_partition_of(table_name, child_table_name, constraint_clause, **options)
     end
@@ -154,16 +154,8 @@ module PgParty
       end
     end
 
-    def quote_range_constraint(value)
-      "(#{Array.wrap(value).map(&method(:quote)).join(",")})"
-    end
-
-    def quote_list_constraint(value)
-      if value.is_a?(Array)
-        "(#{value.map(&method(:quote)).join(",")})"
-      else
-        quote(value)
-      end
+    def quote_collection(values)
+      Array.wrap(values).map(&method(:quote)).join(",")
     end
 
     def uuid_function

--- a/lib/pg_party/model_injector.rb
+++ b/lib/pg_party/model_injector.rb
@@ -3,8 +3,6 @@ module PgParty
     def initialize(model, key)
       @model = model
       @key = key
-
-      @column, @cast = key.to_s.split("::")
     end
 
     def inject_range_methods
@@ -33,15 +31,18 @@ module PgParty
     def create_class_attributes
       @model.class_attribute(
         :partition_key,
-        :partition_column,
-        :partition_cast,
+        :complex_partition_key,
         instance_accessor: false,
         instance_predicate: false
       )
 
-      @model.partition_key = @key
-      @model.partition_column = @column
-      @model.partition_cast = @cast
+      if @key.is_a?(Proc)
+        @model.partition_key = @key.call
+        @model.complex_partition_key = true
+      else
+        @model.partition_key = @key
+        @model.complex_partition_key = false
+      end
     end
   end
 end

--- a/spec/adapter/abstract_methods_spec.rb
+++ b/spec/adapter/abstract_methods_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.create_range_partition("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#create_range_partition is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#create_range_partition is not implemented")
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.create_list_partition("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#create_list_partition is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#create_list_partition is not implemented")
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.create_range_partition_of("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#create_range_partition_of is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#create_range_partition_of is not implemented")
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.create_list_partition_of("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#create_list_partition_of is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#create_list_partition_of is not implemented")
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.attach_range_partition("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#attach_range_partition is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#attach_range_partition is not implemented")
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.attach_list_partition("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#attach_list_partition is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#attach_list_partition is not implemented")
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     subject { adapter.detach_partition("args") }
 
     it "raises not implemented error" do
-      expect { subject }.to raise_error(NotImplementedError, "#detach_partition is not implemented")
+      expect { subject }.to raise_error(RuntimeError, "#detach_partition is not implemented")
     end
   end
 end

--- a/spec/adapter_decorator_spec.rb
+++ b/spec/adapter_decorator_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"id\"))"
+          options: "PARTITION BY RANGE (\"id\")"
         )
 
         subject
@@ -86,7 +86,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"id\"))"
+          options: "PARTITION BY RANGE (\"id\")"
         )
 
         subject
@@ -105,7 +105,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"id\"))"
+          options: "PARTITION BY RANGE (\"id\")"
         )
 
         subject
@@ -139,7 +139,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"some_column\"))"
+          options: "PARTITION BY RANGE (\"some_column\")"
         )
 
         subject
@@ -163,7 +163,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"uid\"))"
+          options: "PARTITION BY RANGE (\"uid\")"
         )
 
         subject
@@ -175,9 +175,9 @@ RSpec.describe PgParty::AdapterDecorator do
       end
     end
 
-    context "with casted partition key" do
+    context "with complex partition key" do
       subject do
-        decorator.create_range_partition(:table_name, partition_key: "created_at::date") do |t|
+        decorator.create_range_partition(:table_name, partition_key: ->{ "(created_at::date)" }) do |t|
           t.timestamps null: false
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY RANGE ((\"created_at\"::\"date\"))"
+          options: "PARTITION BY RANGE ((created_at::date))"
         )
 
         subject
@@ -214,7 +214,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"id\"))"
+          options: "PARTITION BY LIST (\"id\")"
         )
 
         subject
@@ -241,7 +241,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"id\"))"
+          options: "PARTITION BY LIST (\"id\")"
         )
 
         subject
@@ -260,7 +260,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"id\"))"
+          options: "PARTITION BY LIST (\"id\")"
         )
 
         subject
@@ -294,7 +294,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"some_column\"))"
+          options: "PARTITION BY LIST (\"some_column\")"
         )
 
         subject
@@ -318,7 +318,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"uid\"))"
+          options: "PARTITION BY LIST (\"uid\")"
         )
 
         subject
@@ -330,9 +330,9 @@ RSpec.describe PgParty::AdapterDecorator do
       end
     end
 
-    context "with casted partition key" do
+    context "with complex partition key" do
       subject do
-        decorator.create_list_partition(:table_name, partition_key: "created_at::date") do |t|
+        decorator.create_list_partition(:table_name, partition_key: ->{ "(created_at::date)"}) do |t|
           t.timestamps null: false
         end
       end
@@ -341,7 +341,7 @@ RSpec.describe PgParty::AdapterDecorator do
         expect(adapter).to receive(:create_table).with(
           :table_name,
           id: false,
-          options: "PARTITION BY LIST ((\"created_at\"::\"date\"))"
+          options: "PARTITION BY LIST ((created_at::date))"
         )
 
         subject
@@ -377,9 +377,9 @@ RSpec.describe PgParty::AdapterDecorator do
 
     let(:create_index_sql) do
       <<-SQL
-        CREATE INDEX "index_child_on_key"
+        CREATE INDEX "index_child_on_partition_key"
         ON "child"
-        USING btree (("key"))
+        USING btree ("key")
       SQL
     end
 
@@ -555,9 +555,9 @@ RSpec.describe PgParty::AdapterDecorator do
 
     let(:create_index_sql) do
       <<-SQL
-        CREATE INDEX "index_child_on_key"
+        CREATE INDEX "index_child_on_partition_key"
         ON "child"
-        USING btree (("key"))
+        USING btree ("key")
       SQL
     end
 

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
   subject(:create_range_partition) do
     adapter.create_range_partition(
       table_name,
-      partition_key: "created_at::date",
+      partition_key: ->{ "(created_at::date)" },
       primary_key: :custom_id,
       id: :uuid,
       &timestamps_block
@@ -50,7 +50,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
       name: child_table_name,
       index: true,
       primary_key: :custom_id,
-      partition_key: "created_at::date",
+      partition_key: ->{ "(created_at::date)" },
       start_range: start_range,
       end_range: end_range
     )
@@ -166,7 +166,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
 
     let(:index_sql) do
       <<-SQL
-        CREATE INDEX index_#{child_table_name}_on_created_at_date
+        CREATE INDEX index_#{child_table_name}_on_partition_key
         ON #{child_table_name}
         USING btree (((created_at)::date));
       SQL

--- a/spec/internal/app/models/bigint_date_range.rb
+++ b/spec/internal/app/models/bigint_date_range.rb
@@ -1,3 +1,3 @@
 class BigintDateRange < ApplicationRecord
-  range_partition_by "created_at::date"
+  range_partition_by ->{ "(created_at::date)" }
 end

--- a/spec/internal/app/models/bigint_month_range.rb
+++ b/spec/internal/app/models/bigint_month_range.rb
@@ -1,0 +1,3 @@
+class BigintMonthRange < ApplicationRecord
+  range_partition_by ->{ "EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)" }
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -4,21 +4,37 @@ ActiveRecord::Schema.define do
   enable_extension "uuid-ossp"
   enable_extension "pgcrypto"
 
-  create_range_partition :bigint_date_ranges, partition_key: "created_at::date" do |t|
+  create_range_partition :bigint_date_ranges, partition_key: ->{ "(created_at::date)" } do |t|
     t.timestamps null: false
   end
 
   create_range_partition_of :bigint_date_ranges,
     name: :bigint_date_ranges_a,
-    partition_key: "created_at::date",
+    partition_key: ->{ "(created_at::date)" },
     start_range: Date.today,
     end_range: Date.tomorrow
 
   create_range_partition_of :bigint_date_ranges,
     name: :bigint_date_ranges_b,
-    partition_key: "created_at::date",
+    partition_key: ->{ "(created_at::date)" },
     start_range: Date.tomorrow,
     end_range: Date.tomorrow + 1
+
+  create_range_partition :bigint_month_ranges, partition_key: ->{ "EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)" } do |t|
+    t.timestamps null: false
+  end
+
+  create_range_partition_of :bigint_month_ranges,
+    name: :bigint_month_ranges_a,
+    partition_key: ->{ "EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)" },
+    start_range: [Date.today.year, Date.today.month],
+    end_range: [(Date.today + 1.month).year, (Date.today + 1.month).month]
+
+  create_range_partition_of :bigint_month_ranges,
+    name: :bigint_month_ranges_b,
+    partition_key: ->{ "EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)" },
+    start_range: [(Date.today + 1.month).year, (Date.today + 1.month).month],
+    end_range: [(Date.today + 2.months).year, (Date.today + 2.months).month]
 
   create_range_partition :bigint_custom_id_int_ranges, primary_key: :some_id, partition_key: :some_int do |t|
     t.integer :some_int, null: false

--- a/spec/model_injector_spec.rb
+++ b/spec/model_injector_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe PgParty::ModelInjector do
-  let(:key) { "created_at::date" }
+  let(:key) { "created_at" }
   let(:model) { Class.new }
 
   subject(:injector) { described_class.new(model, key) }
@@ -13,50 +13,100 @@ RSpec.describe PgParty::ModelInjector do
   describe "#inject_range_methods" do
     subject { inject_range_methods }
 
-    it "extends range methods" do
-      expect(model).to receive(:extend).with(PgParty::Model::RangeMethods)
-      subject
-    end
-
-    it "extends shared methods" do
-      expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
-      subject
-    end
-
-    describe "model" do
-      subject do
-        inject_range_methods
-        model
+    context "when key is a string" do
+      it "extends range methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::RangeMethods)
+        subject
       end
 
-      its(:partition_key) { is_expected.to eq("created_at::date") }
-      its(:partition_column) { is_expected.to eq("created_at") }
-      its(:partition_cast) { is_expected.to eq("date") }
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_range_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at") }
+        its(:complex_partition_key) { is_expected.to eq(false) }
+      end
+    end
+
+    context "when key is a proc" do
+      let(:key) { ->{ "created_at::date" } }
+
+      it "extends range methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::RangeMethods)
+        subject
+      end
+
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_range_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at::date") }
+        its(:complex_partition_key) { is_expected.to eq(true) }
+      end
     end
   end
 
   describe "#inject_list_methods" do
     subject { inject_list_methods }
 
-    it "extends range methods" do
-      expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
-      subject
-    end
-
-    it "extends shared methods" do
-      expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
-      subject
-    end
-
-    describe "model" do
-      subject do
-        inject_list_methods
-        model
+    context "when key is a string" do
+      it "extends range methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
+        subject
       end
 
-      its(:partition_key) { is_expected.to eq("created_at::date") }
-      its(:partition_column) { is_expected.to eq("created_at") }
-      its(:partition_cast) { is_expected.to eq("date") }
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_list_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at") }
+        its(:complex_partition_key) { is_expected.to eq(false) }
+      end
+    end
+
+    context "when key is a proc" do
+      let(:key) { ->{ "created_at::date" } }
+
+      it "extends range methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
+        subject
+      end
+
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_list_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at::date") }
+        its(:complex_partition_key) { is_expected.to eq(true) }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds full support for creating / adding tables with "complex" partition keys (e.g. `EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)`).

Unfortunately, due to ActiveRecord / Arel, it is very difficult to support these types of keys in the `partition_key_eq` and `partition_key_in` query methods (at least in a way that's consistently chainable with other query methods). So, these methods will be disabled when a complex partition key is detected.

Previously, there were special accommodations for a specific type of key (`column::cast`). This doesn't seem like a maintainable strategy, so going forward these keys are also lumped into the group of "complex" partition keys and the above limitations will apply.

Addresses #9 