### PR TITLE
Support primary_key_prefix_type config option

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -77,7 +77,7 @@ module PgParty
     def create_partition(table_name, type, partition_key, **options)
       modified_options = options.except(:id, :primary_key)
       id               = options.fetch(:id, :bigserial)
-      primary_key      = options.fetch(:primary_key, :id)
+      primary_key      = options.fetch(:primary_key) { primary_key_for_table(table_name) }
 
       raise ArgumentError, "composite primary key not supported" if primary_key.is_a?(Array)
 
@@ -101,7 +101,7 @@ module PgParty
     end
 
     def create_partition_of(table_name, child_table_name, constraint_clause, **options)
-      primary_key   = options.fetch(:primary_key, :id)
+      primary_key   = options.fetch(:primary_key) { primary_key_for_table(table_name) }
       index         = options.fetch(:index, true)
       partition_key = options[:partition_key]
 
@@ -146,6 +146,10 @@ module PgParty
       else
         __getobj__.quote(value)
       end
+    end
+
+    def primary_key_for_table(table_name)
+      ActiveRecord::Base.get_primary_key(table_name.to_s.singularize).to_sym
     end
 
     def quote_partition_key(key)

--- a/spec/adapter_decorator_spec.rb
+++ b/spec/adapter_decorator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe PgParty::AdapterDecorator do
     allow(adapter).to receive(:quote_table_name) { |name| "\"#{name}\"" }
     allow(adapter).to receive(:quote_column_name) { |name| "\"#{name}\"" }
     allow(adapter).to receive(:quote) { |value| "'#{value}'" }
+    allow(ActiveRecord::Base).to receive(:get_primary_key).and_return("id")
 
     if uuid_function == "gen_random_uuid()"
       allow(adapter).to receive(:supports_pgcrypto_uuid?).and_return(true)


### PR DESCRIPTION
Instead of defaulting to `id` when a pk is not provided, leverage the `config.active_record.primary_key_prefix_type` option.

https://guides.rubyonrails.org/configuring.html#configuring-active-record