### PR TITLE
Introduce template tables to retain indexes when creating child partitions

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -2,6 +2,7 @@
 
 require "digest"
 require "pg_party/cache"
+require "pg_party/schema_helper"
 
 module PgParty
   class AdapterDecorator < SimpleDelegator
@@ -20,19 +21,17 @@ module PgParty
     end
 
     def create_range_partition_of(table_name, start_range:, end_range:, **options)
-      constraint_clause = "FROM (#{quote_collection(start_range)}) TO (#{quote_collection(end_range)})"
-
-      create_partition_of(table_name, constraint_clause, **options)
+      create_partition_of(table_name, range_constraint_clause(start_range, end_range), **options)
     end
 
     def create_list_partition_of(table_name, values:, **options)
-      constraint_clause = "IN (#{quote_collection(values)})"
-
-      create_partition_of(table_name, constraint_clause, **options)
+      create_partition_of(table_name, list_constraint_clause(values), **options)
     end
 
     def create_table_like(table_name, new_table_name, **options)
       primary_key = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+
+      validate_primary_key(primary_key)
 
       execute(<<-SQL)
         CREATE TABLE #{quote_table_name(new_table_name)} (
@@ -50,23 +49,11 @@ module PgParty
     end
 
     def attach_range_partition(parent_table_name, child_table_name, start_range:, end_range:)
-      execute(<<-SQL)
-        ALTER TABLE #{quote_table_name(parent_table_name)}
-        ATTACH PARTITION #{quote_table_name(child_table_name)}
-        FOR VALUES FROM (#{quote_collection(start_range)}) TO (#{quote_collection(end_range)})
-      SQL
-
-      PgParty::Cache.clear!
+      attach_partition(parent_table_name, child_table_name, range_constraint_clause(start_range, end_range))
     end
 
     def attach_list_partition(parent_table_name, child_table_name, values:)
-      execute(<<-SQL)
-        ALTER TABLE #{quote_table_name(parent_table_name)}
-        ATTACH PARTITION #{quote_table_name(child_table_name)}
-        FOR VALUES IN (#{quote_collection(values)})
-      SQL
-
-      PgParty::Cache.clear!
+      attach_partition(parent_table_name, child_table_name, list_constraint_clause(values))
     end
 
     def detach_partition(parent_table_name, child_table_name)
@@ -81,16 +68,17 @@ module PgParty
     private
 
     def create_partition(table_name, type, partition_key, **options)
-      modified_options = options.except(:id, :primary_key)
+      modified_options = options.except(:id, :primary_key, :template)
+      template         = options.fetch(:template, true)
       id               = options.fetch(:id, :bigserial)
       primary_key      = options.fetch(:primary_key) { calculate_primary_key(table_name) }
 
-      raise ArgumentError, "composite primary key not supported" if primary_key.is_a?(Array)
+      validate_primary_key(primary_key)
 
       modified_options[:id]      = false
       modified_options[:options] = "PARTITION BY #{type.to_s.upcase} (#{quote_partition_key(partition_key)})"
 
-      result = create_table(table_name, modified_options) do |td|
+      create_table(table_name, modified_options) do |td|
         if id == :uuid
           td.column(primary_key, id, null: false, default: uuid_function)
         elsif id
@@ -103,44 +91,35 @@ module PgParty
       # Rails 4 has a bug where uuid columns are always nullable
       change_column_null(table_name, primary_key, false) if id == :uuid
 
-      result
+      return unless template
+
+      create_table_like(table_name, template_table_name(table_name), primary_key: primary_key)
     end
 
     def create_partition_of(table_name, constraint_clause, **options)
-      primary_key      = options.fetch(:primary_key) { calculate_primary_key(table_name) }
-      child_table_name = options.fetch(:name) { hashed_table_name(table_name, constraint_clause) }
-      index            = options.fetch(:index, true)
-      partition_key    = options[:partition_key]
+      child_table_name    = options.fetch(:name) { hashed_table_name(table_name, constraint_clause) }
+      primary_key         = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+      template_table_name = template_table_name(table_name)
 
-      raise ArgumentError, "composite primary key not supported" if primary_key.is_a?(Array)
+      if PgParty::SchemaHelper.table_exists?(template_table_name)
+        create_table_like(template_table_name, child_table_name)
+      else
+        create_table_like(table_name, child_table_name, primary_key: primary_key)
+      end
 
-      quoted_primary_key = quote_column_name(primary_key) if primary_key
-      quoted_partition_key = quote_partition_key(partition_key) if partition_key
+      attach_partition(table_name, child_table_name, constraint_clause)
 
+      child_table_name
+    end
+
+    def attach_partition(parent_table_name, child_table_name, constraint_clause)
       execute(<<-SQL)
-        CREATE TABLE #{quote_table_name(child_table_name)}
-        PARTITION OF #{quote_table_name(table_name)}
+        ALTER TABLE #{quote_table_name(parent_table_name)}
+        ATTACH PARTITION #{quote_table_name(child_table_name)}
         FOR VALUES #{constraint_clause}
       SQL
 
-      if primary_key
-        execute(<<-SQL)
-          ALTER TABLE #{quote_table_name(child_table_name)}
-          ADD PRIMARY KEY (#{quoted_primary_key})
-        SQL
-      end
-
-      if index && quoted_partition_key && quoted_partition_key != quoted_primary_key
-        execute(<<-SQL)
-          CREATE INDEX #{quote_table_name(index_name(child_table_name))}
-          ON #{quote_table_name(child_table_name)}
-          USING btree (#{quoted_partition_key})
-        SQL
-      end
-
       PgParty::Cache.clear!
-
-      child_table_name
     end
 
     # Rails 5.2 now returns boolean literals
@@ -163,6 +142,10 @@ module PgParty
       ActiveRecord::Base.get_primary_key(table_name.to_s.singularize).to_sym
     end
 
+    def validate_primary_key(key)
+      raise ArgumentError, "composite primary key not supported" if key.is_a?(Array)
+    end
+
     def quote_partition_key(key)
       if key.is_a?(Proc)
         key.call.to_s # very difficult to determine how to sanitize a complex expression
@@ -175,6 +158,18 @@ module PgParty
       Array.wrap(values).map(&method(:quote)).join(",")
     end
 
+    def template_table_name(table_name)
+      "#{table_name}_template"
+    end
+
+    def range_constraint_clause(start_range, end_range)
+      "FROM (#{quote_collection(start_range)}) TO (#{quote_collection(end_range)})"
+    end
+
+    def list_constraint_clause(values)
+      "IN (#{quote_collection(values)})"
+    end
+
     def uuid_function
       try(:supports_pgcrypto_uuid?) ? "gen_random_uuid()" : "uuid_generate_v4()"
     end
@@ -185,10 +180,6 @@ module PgParty
 
     def supports_partitions?
       __getobj__.send(:postgresql_version) >= 100000
-    end
-
-    def index_name(table_name)
-      "index_#{table_name}_on_partition_key"
     end
   end
 end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -102,7 +102,7 @@ module PgParty
       template_table_name = template_table_name(table_name)
 
       if PgParty::SchemaHelper.table_exists?(template_table_name)
-        create_table_like(template_table_name, child_table_name)
+        create_table_like(template_table_name, child_table_name, primary_key: false)
       else
         create_table_like(table_name, child_table_name, primary_key: primary_key)
       end

--- a/lib/pg_party/schema_helper.rb
+++ b/lib/pg_party/schema_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PgParty
+  class SchemaHelper
+    class << self
+      def table_exists?(table_name)
+        schema_cache.send(table_exists_method, table_name)
+      end
+
+      private
+
+      def table_exists_method
+        [:data_source_exists?, :table_exists?].detect do |meth|
+          schema_cache.respond_to?(meth)
+        end
+      end
+
+      def schema_cache
+        ActiveRecord::Base.connection.schema_cache
+      end
+    end
+  end
+end

--- a/spec/adapter_decorator_spec.rb
+++ b/spec/adapter_decorator_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to eq(:child) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", :child)
+        expect(decorator).to receive(:create_table_like).with("parent_template", :child, primary_key: false)
         subject
       end
 
@@ -414,7 +414,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to eq(:child) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", :child)
+        expect(decorator).to receive(:create_table_like).with("parent_template", :child, primary_key: false)
         subject
       end
 
@@ -436,7 +436,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to match(/^parent_/) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", /^parent_/)
+        expect(decorator).to receive(:create_table_like).with("parent_template", /^parent_/, primary_key: false)
         subject
       end
 
@@ -546,7 +546,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to eq(:child) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", :child)
+        expect(decorator).to receive(:create_table_like).with("parent_template", :child, primary_key: false)
         subject
       end
 
@@ -568,7 +568,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to eq(:child) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", :child)
+        expect(decorator).to receive(:create_table_like).with("parent_template", :child, primary_key: false)
         subject
       end
 
@@ -589,7 +589,7 @@ RSpec.describe PgParty::AdapterDecorator do
       it { is_expected.to match(/^parent_/) }
 
       it "calls create_table_like with template table" do
-        expect(decorator).to receive(:create_table_like).with("parent_template", /^parent_/)
+        expect(decorator).to receive(:create_table_like).with("parent_template", /^parent_/, primary_key: false)
         subject
       end
 

--- a/spec/integration/model/bigint_boolean_list_spec.rb
+++ b/spec/integration/model/bigint_boolean_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BigintBooleanList do
   describe ".create" do
     let(:some_bool) { true }
 
-    subject { described_class.create(some_bool: some_bool) }
+    subject { described_class.create!(some_bool: some_bool) }
 
     context "when partition key in list" do
       its(:id) { is_expected.to be_an(Integer) }
@@ -46,9 +46,9 @@ RSpec.describe BigintBooleanList do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(some_bool: true) }
-      let!(:record_two) { described_class.create(some_bool: true) }
-      let!(:record_three) { described_class.create(some_bool: false) }
+      let!(:record_one) { described_class.create!(some_bool: true) }
+      let!(:record_two) { described_class.create!(some_bool: true) }
+      let!(:record_three) { described_class.create!(some_bool: false) }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }
@@ -67,9 +67,9 @@ RSpec.describe BigintBooleanList do
   describe ".partition_key_in" do
     let(:values) { true }
 
-    let!(:record_one) { described_class.create(some_bool: true) }
-    let!(:record_two) { described_class.create(some_bool: true) }
-    let!(:record_three) { described_class.create(some_bool: false) }
+    let!(:record_one) { described_class.create!(some_bool: true) }
+    let!(:record_two) { described_class.create!(some_bool: true) }
+    let!(:record_three) { described_class.create!(some_bool: false) }
 
     subject { described_class.partition_key_in(values) }
 
@@ -95,8 +95,8 @@ RSpec.describe BigintBooleanList do
   describe ".partition_key_eq" do
     let(:partition_key) { true }
 
-    let!(:record_one) { described_class.create(some_bool: true) }
-    let!(:record_two) { described_class.create(some_bool: false) }
+    let!(:record_one) { described_class.create!(some_bool: true) }
+    let!(:record_two) { described_class.create!(some_bool: false) }
 
     subject { described_class.partition_key_eq(partition_key) }
 

--- a/spec/integration/model/bigint_boolean_list_spec.rb
+++ b/spec/integration/model/bigint_boolean_list_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe BigintBooleanList do
 
   describe ".create_partition" do
     let(:values) { true }
+    let(:child_table_name) { "#{table_name}_c" }
 
-    subject { described_class.create_partition(values: values) }
+    subject(:create_partition) { described_class.create_partition(values: values, name: child_table_name) }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
 
     context "when values overlap" do
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/bigint_custom_id_int_list_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BigintCustomIdIntList do
   describe ".create" do
     let(:some_int) { 1 }
 
-    subject { described_class.create(some_int: some_int) }
+    subject { described_class.create!(some_int: some_int) }
 
     context "when partition key in list" do
       its(:id) { is_expected.to be_a(Integer) }
@@ -74,9 +74,9 @@ RSpec.describe BigintCustomIdIntList do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(some_int: 1) }
-      let!(:record_two) { described_class.create(some_int: 2) }
-      let!(:record_three) { described_class.create(some_int: 4) }
+      let!(:record_one) { described_class.create!(some_int: 1) }
+      let!(:record_two) { described_class.create!(some_int: 2) }
+      let!(:record_three) { described_class.create!(some_int: 4) }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }
@@ -95,9 +95,9 @@ RSpec.describe BigintCustomIdIntList do
   describe ".partition_key_in" do
     let(:values) { [1, 2] }
 
-    let!(:record_one) { described_class.create(some_int: 1) }
-    let!(:record_two) { described_class.create(some_int: 2) }
-    let!(:record_three) { described_class.create(some_int: 4) }
+    let!(:record_one) { described_class.create!(some_int: 1) }
+    let!(:record_two) { described_class.create!(some_int: 2) }
+    let!(:record_three) { described_class.create!(some_int: 4) }
 
     subject { described_class.partition_key_in(values) }
 
@@ -121,8 +121,8 @@ RSpec.describe BigintCustomIdIntList do
   describe ".partition_key_eq" do
     let(:partition_key) { 1 }
 
-    let!(:record_one) { described_class.create(some_int: 1) }
-    let!(:record_two) { described_class.create(some_int: 3) }
+    let!(:record_one) { described_class.create!(some_int: 1) }
+    let!(:record_two) { described_class.create!(some_int: 3) }
 
     subject { described_class.partition_key_eq(partition_key) }
 

--- a/spec/integration/model/bigint_custom_id_int_list_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_list_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe BigintCustomIdIntList do
     let(:values) { [5, 6] }
     let(:child_table_name) { "#{table_name}_c" }
 
-    subject { described_class.create_partition(values: values, name: child_table_name) }
+    subject(:create_partition) { described_class.create_partition(values: values, name: child_table_name) }
+    subject(:partitions) { described_class.partitions }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
 
     context "when values do not overlap" do
       before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to eq(child_table_name) }
+      it "returns table name and adds it to partition list" do
+        expect(create_partition).to eq(child_table_name)
 
-      it "adds to partition list" do
-        subject
-
-        expect(described_class.partitions).to contain_exactly(
+        expect(partitions).to contain_exactly(
           "#{table_name}_a",
           "#{table_name}_b",
           "#{table_name}_c"
@@ -57,8 +57,9 @@ RSpec.describe BigintCustomIdIntList do
     context "when values overlap" do
       let(:values) { [2, 3] }
 
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/bigint_custom_id_int_range_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_range_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BigintCustomIdIntRange do
     let(:end_range) { 30 }
     let(:child_table_name) { "#{table_name}_c" }
 
-    subject do
+    subject(:create_partition) do
       described_class.create_partition(
         start_range: start_range,
         end_range: end_range,
@@ -44,16 +44,17 @@ RSpec.describe BigintCustomIdIntRange do
       )
     end
 
+    subject(:partitions) { described_class.partitions }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
+
     context "when ranges do not overlap" do
       before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to eq(child_table_name) }
+      it "returns table name and adds it to partition list" do
+        expect(create_partition).to eq(child_table_name)
 
-      it "adds to partition list" do
-        subject
-
-        expect(described_class.partitions).to contain_exactly(
+        expect(partitions).to contain_exactly(
           "#{table_name}_a",
           "#{table_name}_b",
           "#{table_name}_c"
@@ -64,8 +65,9 @@ RSpec.describe BigintCustomIdIntRange do
     context "when ranges overlap" do
       let(:start_range) { 19 }
 
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/bigint_custom_id_int_range_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_range_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BigintCustomIdIntRange do
   describe ".create" do
     let(:some_int) { 5 }
 
-    subject { described_class.create(some_int: some_int) }
+    subject { described_class.create!(some_int: some_int) }
 
     context "when partition key in range" do
       its(:id) { is_expected.to be_a(Integer) }
@@ -81,9 +81,9 @@ RSpec.describe BigintCustomIdIntRange do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(some_int: 0) }
-      let!(:record_two) { described_class.create(some_int: 9) }
-      let!(:record_three) { described_class.create(some_int: 19) }
+      let!(:record_one) { described_class.create!(some_int: 0) }
+      let!(:record_two) { described_class.create!(some_int: 9) }
+      let!(:record_three) { described_class.create!(some_int: 19) }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }
@@ -103,9 +103,9 @@ RSpec.describe BigintCustomIdIntRange do
     let(:start_range) { 0 }
     let(:end_range) { 10 }
 
-    let!(:record_one) { described_class.create(some_int: 0) }
-    let!(:record_two) { described_class.create(some_int: 9) }
-    let!(:record_three) { described_class.create(some_int: 19) }
+    let!(:record_one) { described_class.create!(some_int: 0) }
+    let!(:record_two) { described_class.create!(some_int: 9) }
+    let!(:record_three) { described_class.create!(some_int: 19) }
 
     subject { described_class.partition_key_in(start_range, end_range) }
 
@@ -129,8 +129,8 @@ RSpec.describe BigintCustomIdIntRange do
   describe ".partition_key_eq" do
     let(:partition_key) { 0 }
 
-    let!(:record_one) { described_class.create(some_int: 0) }
-    let!(:record_two) { described_class.create(some_int: 10) }
+    let!(:record_one) { described_class.create!(some_int: 0) }
+    let!(:record_two) { described_class.create!(some_int: 10) }
 
     subject { described_class.partition_key_eq(partition_key) }
 

--- a/spec/integration/model/bigint_date_range_spec.rb
+++ b/spec/integration/model/bigint_date_range_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BigintDateRange do
   describe ".create" do
     let(:created_at) { current_time }
 
-    subject { described_class.create(created_at: created_at) }
+    subject { described_class.create!(created_at: created_at) }
 
     context "when partition key in range" do
       its(:id) { is_expected.to be_an(Integer) }
@@ -83,9 +83,9 @@ RSpec.describe BigintDateRange do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(created_at: current_time) }
-      let!(:record_two) { described_class.create(created_at: current_time + 1.minute) }
-      let!(:record_three) { described_class.create(created_at: current_time + 1.day) }
+      let!(:record_one) { described_class.create!(created_at: current_time) }
+      let!(:record_two) { described_class.create!(created_at: current_time + 1.minute) }
+      let!(:record_three) { described_class.create!(created_at: current_time + 1.day) }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }

--- a/spec/integration/model/bigint_date_range_spec.rb
+++ b/spec/integration/model/bigint_date_range_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BigintDateRange do
     let(:end_range) { current_date + 3.days }
     let(:child_table_name) { "#{table_name}_c" }
 
-    subject do
+    subject(:create_partition) do
       described_class.create_partition(
         start_range: start_range,
         end_range: end_range,
@@ -46,16 +46,17 @@ RSpec.describe BigintDateRange do
       )
     end
 
+    subject(:partitions) { described_class.partitions }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
+
     context "when ranges do not overlap" do
       before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to eq(child_table_name) }
+      it "returns table name and adds it to partition list" do
+        expect(create_partition).to eq(child_table_name)
 
-      it "adds to partition list" do
-        subject
-
-        expect(described_class.partitions).to contain_exactly(
+        expect(partitions).to contain_exactly(
           "#{table_name}_a",
           "#{table_name}_b",
           "#{table_name}_c"
@@ -66,8 +67,9 @@ RSpec.describe BigintDateRange do
     context "when ranges overlap" do
       let(:start_range) { current_date }
 
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/bigint_month_range_spec.rb
+++ b/spec/integration/model/bigint_month_range_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BigintMonthRange do
   describe ".create" do
     let(:created_at) { current_time }
 
-    subject { described_class.create(created_at: created_at) }
+    subject { described_class.create!(created_at: created_at) }
 
     context "when partition key in range" do
       its(:id) { is_expected.to be_an(Integer) }
@@ -85,9 +85,9 @@ RSpec.describe BigintMonthRange do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(created_at: current_time) }
-      let!(:record_two) { described_class.create(created_at: current_time.end_of_month) }
-      let!(:record_three) { described_class.create(created_at: (current_time + 1.month).end_of_month) }
+      let!(:record_one) { described_class.create!(created_at: current_time) }
+      let!(:record_two) { described_class.create!(created_at: current_time.end_of_month) }
+      let!(:record_three) { described_class.create!(created_at: (current_time + 1.month).end_of_month) }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }

--- a/spec/integration/model/bigint_month_range_spec.rb
+++ b/spec/integration/model/bigint_month_range_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BigintMonthRange do
     let(:end_range) { [end_date.year, end_date.month] }
     let(:child_table_name) { "#{table_name}_c" }
 
-    subject do
+    subject(:create_partition) do
       described_class.create_partition(
         start_range: start_range,
         end_range: end_range,
@@ -48,16 +48,17 @@ RSpec.describe BigintMonthRange do
       )
     end
 
+    subject(:partitions) { described_class.partitions }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
+
     context "when ranges do not overlap" do
       before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to eq(child_table_name) }
+      it "returns table name and adds it to partition list" do
+        expect(create_partition).to eq(child_table_name)
 
-      it "adds to partition list" do
-        subject
-
-        expect(described_class.partitions).to contain_exactly(
+        expect(partitions).to contain_exactly(
           "#{table_name}_a",
           "#{table_name}_b",
           "#{table_name}_c"
@@ -68,8 +69,9 @@ RSpec.describe BigintMonthRange do
     context "when ranges overlap" do
       let(:start_date) { current_date - 1.month }
 
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/uuid_string_list_spec.rb
+++ b/spec/integration/model/uuid_string_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UuidStringList do
   describe ".create" do
     let(:some_string) { "a" }
 
-    subject { described_class.create(some_string: some_string) }
+    subject { described_class.create!(some_string: some_string) }
 
     context "when partition key in list" do
       its(:id) { is_expected.to be_a_uuid }
@@ -74,9 +74,9 @@ RSpec.describe UuidStringList do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(some_string: "a") }
-      let!(:record_two) { described_class.create(some_string: "b") }
-      let!(:record_three) { described_class.create(some_string: "d") }
+      let!(:record_one) { described_class.create!(some_string: "a") }
+      let!(:record_two) { described_class.create!(some_string: "b") }
+      let!(:record_three) { described_class.create!(some_string: "d") }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }
@@ -95,9 +95,9 @@ RSpec.describe UuidStringList do
   describe ".partition_key_in" do
     let(:values) { ["a", "b"] }
 
-    let!(:record_one) { described_class.create(some_string: "a") }
-    let!(:record_two) { described_class.create(some_string: "b") }
-    let!(:record_three) { described_class.create(some_string: "d") }
+    let!(:record_one) { described_class.create!(some_string: "a") }
+    let!(:record_two) { described_class.create!(some_string: "b") }
+    let!(:record_three) { described_class.create!(some_string: "d") }
 
     subject { described_class.partition_key_in(values) }
 
@@ -121,8 +121,8 @@ RSpec.describe UuidStringList do
   describe ".partition_key_eq" do
     let(:partition_key) { "a" }
 
-    let!(:record_one) { described_class.create(some_string: "a") }
-    let!(:record_two) { described_class.create(some_string: "c") }
+    let!(:record_one) { described_class.create!(some_string: "a") }
+    let!(:record_two) { described_class.create!(some_string: "c") }
 
     subject { described_class.partition_key_eq(partition_key) }
 

--- a/spec/integration/model/uuid_string_list_spec.rb
+++ b/spec/integration/model/uuid_string_list_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe UuidStringList do
     let(:values) { ["e", "f"] }
     let(:child_table_name) { "#{table_name}_c" }
 
-    subject { described_class.create_partition(values: values, name: child_table_name) }
+    subject(:create_partition) { described_class.create_partition(values: values, name: child_table_name) }
+    subject(:partitions) { described_class.partitions }
+    subject(:child_table_exists) { PgParty::SchemaHelper.table_exists?(child_table_name) }
 
     context "when values do not overlap" do
       before { described_class.partitions }
       after { connection.drop_table(child_table_name) }
 
-      it { is_expected.to eq(child_table_name) }
+      it "returns table name and adds it to partition list" do
+        expect(create_partition).to eq(child_table_name)
 
-      it "adds to partition list" do
-        subject
-
-        expect(described_class.partitions).to contain_exactly(
+        expect(partitions).to contain_exactly(
           "#{table_name}_a",
           "#{table_name}_b",
           "#{table_name}_c"
@@ -57,8 +57,9 @@ RSpec.describe UuidStringList do
     context "when values overlap" do
       let(:values) { ["b", "c"] }
 
-      it "raises error" do
-        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+      it "raises error and cleans up intermediate table" do
+        expect { create_partition }.to raise_error(ActiveRecord::StatementInvalid, /PG::InvalidObjectDefinition/)
+        expect(child_table_exists).to eq(false)
       end
     end
   end

--- a/spec/integration/model/uuid_string_range_spec.rb
+++ b/spec/integration/model/uuid_string_range_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UuidStringRange do
   describe ".create" do
     let(:some_string) { "c" }
 
-    subject { described_class.create(some_string: some_string) }
+    subject { described_class.create!(some_string: some_string) }
 
     context "when partition key in range" do
       its(:id) { is_expected.to be_a_uuid }
@@ -81,9 +81,9 @@ RSpec.describe UuidStringRange do
     its(:allocate)   { is_expected.to be_an_instance_of(described_class) }
 
     describe "query methods" do
-      let!(:record_one) { described_class.create(some_string: "d") }
-      let!(:record_two) { described_class.create(some_string: "f") }
-      let!(:record_three) { described_class.create(some_string: "x") }
+      let!(:record_one) { described_class.create!(some_string: "d") }
+      let!(:record_two) { described_class.create!(some_string: "f") }
+      let!(:record_three) { described_class.create!(some_string: "x") }
 
       describe ".all" do
         subject { described_class.in_partition(child_table_name).all }
@@ -103,9 +103,9 @@ RSpec.describe UuidStringRange do
     let(:start_range) { "a" }
     let(:end_range) { "l" }
 
-    let!(:record_one) { described_class.create(some_string: "d") }
-    let!(:record_two) { described_class.create(some_string: "f") }
-    let!(:record_three) { described_class.create(some_string: "x") }
+    let!(:record_one) { described_class.create!(some_string: "d") }
+    let!(:record_two) { described_class.create!(some_string: "f") }
+    let!(:record_three) { described_class.create!(some_string: "x") }
 
     subject { described_class.partition_key_in(start_range, end_range) }
 
@@ -129,8 +129,8 @@ RSpec.describe UuidStringRange do
   describe ".partition_key_eq" do
     let(:partition_key) { "d" }
 
-    let!(:record_one) { described_class.create(some_string: "d") }
-    let!(:record_two) { described_class.create(some_string: "x") }
+    let!(:record_one) { described_class.create!(some_string: "d") }
+    let!(:record_two) { described_class.create!(some_string: "x") }
 
     subject { described_class.partition_key_eq(partition_key) }
 

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -13,15 +13,12 @@ ActiveRecord::Schema.define do
   create_range_partition_of \
     :bigint_date_ranges,
     name: :bigint_date_ranges_a,
-    partition_key: ->{ "(created_at::date)" },
     start_range: Date.today,
     end_range: Date.tomorrow
 
-  create_table_like :bigint_date_ranges_a, :bigint_date_ranges_b
-
-  attach_range_partition \
+  create_range_partition_of \
     :bigint_date_ranges,
-    :bigint_date_ranges_b,
+    name: :bigint_date_ranges_b,
     start_range: Date.tomorrow,
     end_range: Date.tomorrow + 1
 
@@ -29,10 +26,6 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
     t.integer :some_indexed_column
   end
-
-  # Postgres doesn't support adding indexes to a partition table,
-  # so let's define a template table to use when creating child partitions
-  create_table_like :bigint_month_ranges, :bigint_month_ranges_template
 
   add_index :bigint_month_ranges_template, :some_indexed_column
 
@@ -50,19 +43,15 @@ ActiveRecord::Schema.define do
     USING btree (EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at))
   SQL
 
-  # create child partitions from template table, copying over all indexes
-  create_table_like :bigint_month_ranges_template, :bigint_month_ranges_a
-  create_table_like :bigint_month_ranges_template, :bigint_month_ranges_b
-
-  attach_range_partition \
+  create_range_partition_of \
     :bigint_month_ranges,
-    :bigint_month_ranges_a,
+    name: :bigint_month_ranges_a,
     start_range: [Date.today.year, Date.today.month],
     end_range: [(Date.today + 1.month).year, (Date.today + 1.month).month]
 
-  attach_range_partition \
+  create_range_partition_of \
     :bigint_month_ranges,
-    :bigint_month_ranges_b,
+    name: :bigint_month_ranges_b,
     start_range: [(Date.today + 1.month).year, (Date.today + 1.month).month],
     end_range: [(Date.today + 2.months).year, (Date.today + 2.months).month]
 
@@ -73,16 +62,12 @@ ActiveRecord::Schema.define do
   create_range_partition_of \
     :bigint_custom_id_int_ranges,
     name: :bigint_custom_id_int_ranges_a,
-    primary_key: :some_id,
-    partition_key: :some_int,
     start_range: 0,
     end_range: 10
 
-  create_table_like :bigint_custom_id_int_ranges_a, :bigint_custom_id_int_ranges_b
-
-  attach_range_partition \
+  create_range_partition_of \
     :bigint_custom_id_int_ranges,
-    :bigint_custom_id_int_ranges_b,
+    name: :bigint_custom_id_int_ranges_b,
     start_range: 10,
     end_range: 20
 
@@ -93,33 +78,27 @@ ActiveRecord::Schema.define do
   create_range_partition_of \
     :uuid_string_ranges,
     name: :uuid_string_ranges_a,
-    partition_key: :some_string,
     start_range: "a",
     end_range: "l"
 
-  create_table_like :uuid_string_ranges_a, :uuid_string_ranges_b
-
-  attach_range_partition \
+  create_range_partition_of \
     :uuid_string_ranges,
-    :uuid_string_ranges_b,
+    name: :uuid_string_ranges_b,
     start_range: "l",
     end_range: "z"
 
-  create_list_partition :bigint_boolean_lists, partition_key: :some_bool do |t|
+  create_list_partition :bigint_boolean_lists, partition_key: :some_bool, template: false do |t|
     t.boolean :some_bool, default: true, null: false
   end
 
   create_list_partition_of \
     :bigint_boolean_lists,
     name: :bigint_boolean_lists_a,
-    partition_key: :some_bool,
     values: true
 
-  create_table_like :bigint_boolean_lists_a, :bigint_boolean_lists_b
-
-  attach_list_partition \
+  create_list_partition_of \
     :bigint_boolean_lists,
-    :bigint_boolean_lists_b,
+    name: :bigint_boolean_lists_b,
     values: false
 
   create_list_partition :bigint_custom_id_int_lists, primary_key: :some_id, partition_key: :some_int do |t|
@@ -129,15 +108,11 @@ ActiveRecord::Schema.define do
   create_list_partition_of \
     :bigint_custom_id_int_lists,
     name: :bigint_custom_id_int_lists_a,
-    primary_key: :some_id,
-    partition_key: :some_int,
     values: [1, 2]
 
-  create_table_like :bigint_custom_id_int_lists_a, :bigint_custom_id_int_lists_b
-
-  attach_list_partition \
+  create_list_partition_of \
     :bigint_custom_id_int_lists,
-    :bigint_custom_id_int_lists_b,
+    name: :bigint_custom_id_int_lists_b,
     values: [3, 4]
 
   create_list_partition :uuid_string_lists, id: :uuid, partition_key: :some_string do |t|
@@ -147,13 +122,10 @@ ActiveRecord::Schema.define do
   create_list_partition_of \
     :uuid_string_lists,
     name: :uuid_string_lists_a,
-    partiton_key: :some_string,
     values: ["a", "b"]
 
-  create_table_like :uuid_string_lists_a, :uuid_string_lists_b
-
-  attach_list_partition \
+  create_list_partition_of \
     :uuid_string_lists,
-    :uuid_string_lists_b,
+    name: :uuid_string_lists_b,
     values: ["c", "d"]
 end

--- a/spec/schema_helper_spec.rb
+++ b/spec/schema_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PgParty::SchemaHelper do
+  let(:table_name) { "table_name" }
+  let(:adapter) { instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) }
+  let(:schema_cache) { instance_double(ActiveRecord::ConnectionAdapters::SchemaCache) }
+  let(:table_exists_method) do
+    if Rails.gem_version >= Gem::Version.new("5.0")
+      "data_source_exists?"
+    else
+      "table_exists?"
+    end
+  end
+
+  before do
+    allow(ActiveRecord::Base).to receive(:connection).and_return(adapter)
+    allow(adapter).to receive(:schema_cache).and_return(schema_cache)
+    allow(schema_cache).to receive(table_exists_method)
+  end
+
+  describe ".table_exists?" do
+    subject { described_class.table_exists?(table_name) }
+
+    it "calls correct table exists method with table name" do
+      expect(schema_cache).to receive(table_exists_method).with(table_name)
+      subject
+    end
+  end
+end

--- a/spec/support/pg_dump_helper.rb
+++ b/spec/support/pg_dump_helper.rb
@@ -16,7 +16,7 @@ class PgDumpHelper
   end
 
   def pg_dump
-    `#{pg_env_string} pg_dump -s -x -O -d #{config[:database]} -t #{@table_name}`
+    `#{pg_env_string} pg_dump -s -x -O -d #{config[:database]} -t #{@table_name} 2>/dev/null`
   end
 
   def pg_env_string


### PR DESCRIPTION
New feature:

For `create_range_partition` and `create_list_partition` migration methods, a template table (`<table_name>_template`) is automatically created. For `create_range_partition_of` and `create_list_partition_of`, the template table, if exists, will be used to create the child partitions. This allows users to define indexes, constraints, etc _once_ on the template table - everything will be propagated to newly created child partitions.

Note: this functionality can be disabled by passing `template: false` to `create_range_partition` / `create_list_partition`

Removed feature:

When creating child partitions, the functionality to automatically create an index on the partition key has been removed. The workaround for this is to use the feature described above: explicitly create the index on the template table after the initial `create_range_partition` / `create_list_partition` call.

Resolves #17 
Resolves #27 