### PR TITLE
Introduce caching TTL / configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN mkdir /code
 
 WORKDIR /code
 
+COPY . /code
+
+RUN bundle install
+
+RUN rm -rf *
+
 ENV PATH "/code/bin:$PATH"
 
 CMD /bin/sleep infinity

--- a/lib/pg_party.rb
+++ b/lib/pg_party.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
 
 require "pg_party/version"
+require "pg_party/config"
 require "active_support"
+
+module PgParty
+  @config = Config.new
+  @cache = Cache.new
+
+  class << self
+    attr_reader :config, :cache
+
+    def configure(&blk)
+      blk.call(config)
+    end
+
+    def reset
+      @config = Config.new
+      @cache = Cache.new
+    end
+  end
+end
 
 ActiveSupport.on_load(:active_record) do
   require "pg_party/model/methods"

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -61,7 +61,7 @@ module PgParty
         DETACH PARTITION #{quote_table_name(child_table_name)}
       SQL
 
-      PgParty::Cache.clear!
+      PgParty.cache.clear!
     end
 
     private
@@ -118,7 +118,7 @@ module PgParty
         FOR VALUES #{constraint_clause}
       SQL
 
-      PgParty::Cache.clear!
+      PgParty.cache.clear!
     end
 
     # Rails 5.2 now returns boolean literals

--- a/lib/pg_party/cache.rb
+++ b/lib/pg_party/cache.rb
@@ -6,32 +6,64 @@ module PgParty
   class Cache
     LOCK = Mutex.new
 
-    class << self
-      def clear!
-        LOCK.synchronize { store.clear }
+    def initialize
+      # automatically initialize a new hash when
+      # accessing an object id that doesn't exist
+      @store = Hash.new { |h, k| h[k] = { models: {}, partitions: nil } }
+    end
 
-        nil
+    def clear!
+      LOCK.synchronize { @store.clear }
+
+      nil
+    end
+
+    def fetch_model(key, child_table, &block)
+      LOCK.synchronize { fetch_value(@store[key][:models], child_table.to_sym, block) }
+    end
+
+    def fetch_partitions(key, &block)
+      LOCK.synchronize { fetch_value(@store[key], :partitions, block) }
+    end
+
+    private
+
+    def caching_enabled?
+      PgParty.config.caching
+    end
+
+    def fetch_value(subhash, key, block)
+      return block.call unless caching_enabled?
+
+      entry = subhash[key]
+
+      if entry.nil? || entry.expired?
+        entry = Entry.new(block.call)
+        subhash[key] = entry
       end
 
-      def fetch_model(key, child_table, &block)
-        LOCK.synchronize do
-          store[key][:models][child_table.to_sym] ||= block.call
-        end
+      entry.value
+    end
+
+    class Entry
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+        @timestamp = Time.now
       end
 
-      def fetch_partitions(key, &block)
-        LOCK.synchronize do
-          store[key][:partitions] ||= block.call
-        end
+      def expired?
+        ttl.positive? && Time.now - @timestamp > ttl
       end
 
       private
 
-      def store
-        # automatically initialize a new hash when
-        # accessing an object id that doesn't exist
-        @store ||= Hash.new { |h, k| h[k] = { models: {}, partitions: nil } }
+      def ttl
+        PgParty.config.caching_ttl
       end
     end
+
+    private_constant :Entry
   end
 end

--- a/lib/pg_party/config.rb
+++ b/lib/pg_party/config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PgParty
+  class Config
+    attr_accessor :caching, :caching_ttl
+
+    def initialize
+      @caching = true
+      @caching_ttl = -1
+    end
+  end
+end

--- a/lib/pg_party/model_decorator.rb
+++ b/lib/pg_party/model_decorator.rb
@@ -21,7 +21,7 @@ module PgParty
     end
 
     def in_partition(child_table_name)
-      PgParty::Cache.fetch_model(cache_key, child_table_name) do
+      PgParty.cache.fetch_model(cache_key, child_table_name) do
         Class.new(__getobj__) do
           self.table_name = child_table_name
 
@@ -76,7 +76,7 @@ module PgParty
     end
 
     def partitions
-      PgParty::Cache.fetch_partitions(cache_key) do
+      PgParty.cache.fetch_partitions(cache_key) do
         connection.select_values(<<-SQL)
           SELECT pg_inherits.inhrelid::regclass::text
           FROM pg_tables

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PgParty::Config do
+  let(:instance) { described_class.new }
+
+  describe "#caching" do
+    subject { instance.caching }
+
+    context "when defaulted" do
+      it { is_expected.to eq(true) }
+    end
+
+    context "when overridden" do
+      before { instance.caching = false }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#caching_ttl" do
+    subject { instance.caching_ttl }
+
+    context "when defaulted" do
+      it { is_expected.to eq(-1) }
+    end
+
+    context "when overridden" do
+      before { instance.caching_ttl = 60 }
+      it { is_expected.to eq(60) }
+    end
+  end
+end

--- a/spec/integration/model/bigint_boolean_list_spec.rb
+++ b/spec/integration/model/bigint_boolean_list_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe BigintBooleanList do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/bigint_custom_id_int_list_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_list_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BigintCustomIdIntList do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/bigint_custom_id_int_range_spec.rb
+++ b/spec/integration/model/bigint_custom_id_int_range_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BigintCustomIdIntRange do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/bigint_date_range_spec.rb
+++ b/spec/integration/model/bigint_date_range_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe BigintDateRange do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/bigint_month_range_spec.rb
+++ b/spec/integration/model/bigint_month_range_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe BigintMonthRange do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/no_pk_substring_list_spec.rb
+++ b/spec/integration/model/no_pk_substring_list_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe NoPkSubstringList do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/uuid_string_list_spec.rb
+++ b/spec/integration/model/uuid_string_list_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UuidStringList do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/integration/model/uuid_string_range_spec.rb
+++ b/spec/integration/model/uuid_string_range_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UuidStringRange do
     end
 
     context "when an error occurs" do
-      before { allow(PgParty::Cache).to receive(:fetch_partitions).and_raise("boom") }
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
 
       it { is_expected.to eq([]) }
     end

--- a/spec/pg_party_spec.rb
+++ b/spec/pg_party_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PgParty do
+  describe ".configure" do
+    subject do
+      described_class.configure do |c|
+        c.caching = false
+        c.caching_ttl = 60
+      end
+
+      described_class.config
+    end
+
+    its(:caching) { is_expected.to eq(false) }
+    its(:caching_ttl) { is_expected.to eq(60) }
+  end
+
+  describe ".reset" do
+    let!(:initial_config) { described_class.config }
+    let!(:initial_cache) { described_class.cache }
+
+    subject do
+      described_class.reset
+      described_class
+    end
+
+    its(:config) { is_expected.to_not eq(initial_config) }
+    its(:cache) { is_expected.to_not eq(initial_cache) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require "pg_party/model/shared_methods"
 require "pg_party/model/range_methods"
 require "pg_party/model/list_methods"
 
-Timecop.travel(Date.current + 12.hours)
+Timecop.freeze(Date.current + 12.hours)
 
 Combustion.path = "spec/dummy"
 Combustion.initialize! :active_record
@@ -54,6 +54,7 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
+    PgParty.reset
     DatabaseCleaner.start
     example.run
     DatabaseCleaner.clean


### PR DESCRIPTION
The existing caching strategy breaks down for multi-process applications. If a new partition is added, there's not a great way to tell the other processes to clear their cache to discover the partition.

This PR allows users to customize caching behavior:
- Enable / disable it
- Set a global TTL for all cache entries

Checks are done in-place during a cache access, and the value is computed and replaced if the TTL has expired.