### PR TITLE
Ignore child partition tables in structure dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /doc/
 /pkg/
 /spec/results/
+/spec/dummy/db/structure.sql
 /tmp/
 /.ruby-version
 /*.gem

--- a/lib/pg_party.rb
+++ b/lib/pg_party.rb
@@ -40,6 +40,12 @@ ActiveSupport.on_load(:active_record) do
     PgParty::Hacks::SchemaCache
   )
 
+  require "pg_party/hacks/database_tasks"
+
+  ActiveRecord::Tasks::DatabaseTasks.extend(
+    PgParty::Hacks::DatabaseTasks
+  )
+
   begin
     require "active_record/connection_adapters/postgresql_adapter"
     require "pg_party/adapter/postgresql_methods"

--- a/lib/pg_party/hacks/database_tasks.rb
+++ b/lib/pg_party/hacks/database_tasks.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PgParty
+  module Hacks
+    module DatabaseTasks
+      def structure_dump(*)
+        old_ignore_list = ActiveRecord::SchemaDumper.ignore_tables
+        new_ignore_list = partitions.map { |table| "*.#{table}" }
+
+        ActiveRecord::SchemaDumper.ignore_tables = old_ignore_list + new_ignore_list
+
+        super
+      ensure
+        ActiveRecord::SchemaDumper.ignore_tables = old_ignore_list
+      end
+
+      def partitions
+        ActiveRecord::Base.connection.select_values(
+          "SELECT DISTINCT inhrelid::regclass::text FROM pg_inherits"
+        )
+      rescue
+        []
+      end
+    end
+  end
+end

--- a/spec/integration/structure_dump_spec.rb
+++ b/spec/integration/structure_dump_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "db:structure:dump" do
+  let(:skip_test) { Rails.gem_version < Gem::Version.new("5.2") }
+
+  subject do
+    Rake::Task["db:structure:dump"].invoke
+    File.read(File.expand_path("../../dummy/db/structure.sql", __FILE__))
+  end
+
+  it "does not include child partition tables" do
+    skip "only supported in AR 5.2+" if skip_test
+
+    expect(subject).to_not include("bigint_date_ranges_a")
+  end
+
+  it "does include parent partition tables" do
+    skip "only supported in AR 5.2+" if skip_test
+
+    expect(subject).to include("bigint_date_ranges")
+  end
+
+  it "includes child partition tables if the lookup fails" do
+    skip "only supported in AR 5.2+" if skip_test
+
+    allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+      .to receive(:select_values)
+      .and_raise("boom")
+
+    expect(subject).to include("bigint_date_ranges_a")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "combustion"
 require "timecop"
 require "pry-byebug"
 require "simplecov"
+require "rake"
 
 if ENV["CODE_COVERAGE"] == "true"
   SimpleCov.command_name Rails.gem_version.to_s
@@ -24,6 +25,8 @@ Combustion.path = "spec/dummy"
 Combustion.initialize! :active_record do
   config.eager_load = true
 end
+
+load "support/db.rake"
 
 require "rspec/rails"
 require "rspec/its"

--- a/spec/support/db.rake
+++ b/spec/support/db.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: trueQ
+
+require "erb"
+
+include ActiveRecord::Tasks
+
+root_dir = File.expand_path("../../dummy", __FILE__)
+
+DatabaseTasks.env = ENV["RAILS_ENV"]
+DatabaseTasks.root = root_dir
+DatabaseTasks.database_configuration = YAML.load(ERB.new(File.read("#{root_dir}/config/database.yml")).result)
+DatabaseTasks.db_dir = "#{root_dir}/db"
+DatabaseTasks.migrations_paths = "#{root_dir}/db/migrate"
+
+task :environment do
+  ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
+  ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+end
+
+load "active_record/railties/databases.rake"


### PR DESCRIPTION
Resolves #36 

This change relies on `SchemaDumper.ignore_tables` which was only recently modified to work with a structure dump: https://github.com/rails/rails/pull/29077

@justinperkins it'll be pretty difficult to get this working for Rails <5.2. Is this enough to unblock you?