### PR TITLE
Allow configuration of partition table exclusion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,19 +63,19 @@ jobs:
       CONTAINER_PG_VERSION: 11
       RAILS_VERSIONS: "4.2 5.0 5.1 5.2"
 
-  build-ruby-2.6.4-pg-10:
+  build-ruby-2.6.5-pg-10:
     <<: *shared_config
 
     environment:
-      CONTAINER_RUBY_VERSION: 2.6.4
+      CONTAINER_RUBY_VERSION: 2.6.5
       CONTAINER_PG_VERSION: 10
       RAILS_VERSIONS: "4.2 5.0 5.1 5.2 6.0"
 
-  build-ruby-2.6.4-pg-11:
+  build-ruby-2.6.5-pg-11:
     <<: *shared_config
 
     environment:
-      CONTAINER_RUBY_VERSION: 2.6.4
+      CONTAINER_RUBY_VERSION: 2.6.5
       CONTAINER_PG_VERSION: 11
       RAILS_VERSIONS: "4.2 5.0 5.1 5.2 6.0"
       UPLOAD_COVERAGE: true
@@ -86,5 +86,5 @@ workflows:
     jobs:
       - build-ruby-2.3.0-pg-10
       - build-ruby-2.3.0-pg-11
-      - build-ruby-2.6.4-pg-10
-      - build-ruby-2.6.4-pg-11
+      - build-ruby-2.6.5-pg-10
+      - build-ruby-2.6.5-pg-11

--- a/lib/pg_party/config.rb
+++ b/lib/pg_party/config.rb
@@ -2,11 +2,15 @@
 
 module PgParty
   class Config
-    attr_accessor :caching, :caching_ttl
+    attr_accessor \
+      :caching,
+      :caching_ttl,
+      :schema_exclude_partitions
 
     def initialize
       @caching = true
       @caching_ttl = -1
+      @schema_exclude_partitions = true
     end
   end
 end

--- a/lib/pg_party/hacks/database_tasks.rb
+++ b/lib/pg_party/hacks/database_tasks.rb
@@ -5,7 +5,12 @@ module PgParty
     module DatabaseTasks
       def structure_dump(*)
         old_ignore_list = ActiveRecord::SchemaDumper.ignore_tables
-        new_ignore_list = partitions.map { |table| "*.#{table}" }
+
+        if PgParty.config.schema_exclude_partitions
+          new_ignore_list = partitions.map { |table| "*.#{table}" }
+        else
+          new_ignore_list = []
+        end
 
         ActiveRecord::SchemaDumper.ignore_tables = old_ignore_list + new_ignore_list
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe PgParty::Config do
       it { is_expected.to eq(60) }
     end
   end
+
+  describe "#schema_exclude_partitions" do
+    subject { instance.schema_exclude_partitions }
+
+    context "when defaulted" do
+      it { is_expected.to eq(true) }
+    end
+
+    context "when overridden" do
+      before { instance.schema_exclude_partitions = false }
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/integration/structure_dump_spec.rb
+++ b/spec/integration/structure_dump_spec.rb
@@ -5,30 +5,32 @@ require "spec_helper"
 RSpec.describe "db:structure:dump" do
   let(:skip_test) { Rails.gem_version < Gem::Version.new("5.2") }
 
+  before { skip "only supported in AR 5.2+" if skip_test }
+
   subject do
     Rake::Task["db:structure:dump"].invoke
     File.read(File.expand_path("../../dummy/db/structure.sql", __FILE__))
   end
 
-  it "does not include child partition tables" do
-    skip "only supported in AR 5.2+" if skip_test
+  context "when schema_exclude_partitions is true" do
+    it { is_expected.to_not include("bigint_date_ranges_a") }
+    it { is_expected.to include("bigint_date_ranges") }
 
-    expect(subject).to_not include("bigint_date_ranges_a")
+    context "when partition lookup fails" do
+      before do
+        allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+          .to receive(:select_values)
+          .and_raise("boom")
+      end
+
+      it { is_expected.to include("bigint_date_ranges_a") }
+    end
   end
 
-  it "does include parent partition tables" do
-    skip "only supported in AR 5.2+" if skip_test
+  context "when schema_exclude_partitions is false" do
+    before { PgParty.config.schema_exclude_partitions = false }
 
-    expect(subject).to include("bigint_date_ranges")
-  end
-
-  it "includes child partition tables if the lookup fails" do
-    skip "only supported in AR 5.2+" if skip_test
-
-    allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
-      .to receive(:select_values)
-      .and_raise("boom")
-
-    expect(subject).to include("bigint_date_ranges_a")
+    it { is_expected.to include("bigint_date_ranges_a") }
+    it { is_expected.to include("bigint_date_ranges") }
   end
 end

--- a/spec/pg_party_spec.rb
+++ b/spec/pg_party_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PgParty do
       described_class.configure do |c|
         c.caching = false
         c.caching_ttl = 60
+        c.schema_exclude_partitions = false
       end
 
       described_class.config
@@ -15,6 +16,7 @@ RSpec.describe PgParty do
 
     its(:caching) { is_expected.to eq(false) }
     its(:caching_ttl) { is_expected.to eq(60) }
+    its(:schema_exclude_partitions) { is_expected.to eq(false) }
   end
 
   describe ".reset" do

--- a/spec/support/db.rake
+++ b/spec/support/db.rake
@@ -1,4 +1,4 @@
-# frozen_string_literal: trueQ
+# frozen_string_literal: true
 
 require "erb"
 


### PR DESCRIPTION
Related to #36 

This just allows the user to configure whether or not child partitions are excluded from a structure dump.