### PR TITLE
Fix issue in documentation for automatic partition creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ class Log < ApplicationRecord
       Log.create_partition(
         name: name,
         start_range: day.beginning_of_month,
-        end_range: day.end_of_month
+        end_range: day.next_month.beginning_of_month
       )
     end
   end


### PR DESCRIPTION
Current example would lead to this error:
```
ActiveRecord::StatementInvalid (PG::CheckViolation: ERROR:  no partition of relation "logs" found for row)
DETAIL:  Partition key of the failing row contains ((created_at::date)) = (2020-01-31).
```

It happens because `day.end_of_month` is not included in created partitions. So, we would see this error every last day of month.

https://dba.stackexchange.com/questions/196134/postgres-table-partitioning-no-partition-of-relation-parsel-part-found-for-ro