### PR TITLE
Full Postgres 11+ feature support, subpartitioning support, and other enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,18 @@
+## 1.4.0 - Postgres 11+ feature support and enhancements
+Postgres 11 feature support has been added with full backward compatibility.
+* `config.create_template_tables` now governs whether template tables are created by default (defaults true). When starting
+  fresh with Postgres 11+ you may want to disable template tables and enable `config.create_with_primary_key` to use these native features.
+* Set `config.create_with_primary_key` to true to create primary keys on partitioned tables in Postgres 11+
+  * Composite primary keys are now allowed when this setting is enabled
+* `create_hash_partition`, `create_hash_partition_of`, and `attach_hash_partition` methods provide support for Hash partitions in Postgres 11+
+* `create_default_partition_of` and `attach_default_partition` allows adding of default partitions to range and list partitioned tables in Postgres 11+
+* Subpartition support! `create_x_partition_of` methods now support `partition_type` and `partition_key`, which may be supplied to create
+  a partitioned child table. Use `create_x_partition_of` to add a partition to your subpartition.
+  * Template tables are only created for top-level tables but will be correctly used by deeply nested subpartitions
+* The `partitions` command now accepts an `include_subpartitions:` option (default based on config 
+  `include_subpartitions_in_partition_list`) which will cascade to return all
+subpartitions in the hierarchy
+* Added adapter methods `partitions_for_table_name` and `parent_for_table_name` to assist automating partition management
+* Added adapter method `add_index_on_all_partitions` to automatically cascade index creation to all partitions and
+subpartitions, providing support for `algorithm: :concurrently` (which Postgres 11 does not on partitioned tables)
+  * This feature uses the `parallel` gem to allow parallel index creation via the `in_threads:` option

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,22 @@
 ## 1.4.0 - Postgres 11+ feature support and enhancements
-Postgres 11 feature support has been added with full backward compatibility.
-* `config.create_template_tables` now governs whether template tables are created by default (defaults true). When starting
-  fresh with Postgres 11+ you may want to disable template tables and enable `config.create_with_primary_key` to use these native features.
-* Set `config.create_with_primary_key` to true to create primary keys on partitioned tables in Postgres 11+
-  * Composite primary keys are now allowed when this setting is enabled
-* `create_hash_partition`, `create_hash_partition_of`, and `attach_hash_partition` methods provide support for Hash partitions in Postgres 11+
-* `create_default_partition_of` and `attach_default_partition` allows adding of default partitions to range and list partitioned tables in Postgres 11+
-* Subpartition support! `create_x_partition_of` methods now support `partition_type` and `partition_key`, which may be supplied to create
-  a partitioned child table. Use `create_x_partition_of` to add a partition to your subpartition.
-  * Template tables are only created for top-level tables but will be correctly used by deeply nested subpartitions
-* The `partitions` command now accepts an `include_subpartitions:` option (default based on config 
-  `include_subpartitions_in_partition_list`) which will cascade to return all
-subpartitions in the hierarchy
-* Added adapter methods `partitions_for_table_name` and `parent_for_table_name` to assist automating partition management
-* Added adapter method `add_index_on_all_partitions` to automatically cascade index creation to all partitions and
-subpartitions, providing support for `algorithm: :concurrently` (which Postgres 11 does not on partitioned tables)
-  * This feature uses the `parallel` gem to allow parallel index creation via the `in_threads:` option
+#### Full Postgres 11 feature support has been added with complete backward compatibility
+* When starting a fresh project with Postgres 11 or higher, you can disable template tables and enable primary key constraints on partitioned tables:
+    * `config.create_template_tables` now governs whether template tables are created by default (defaults true).
+    * `config.create_with_primary_key` passed down primary key options to CREATE TABLE, including support for composite primary keys
+* `create_hash_partition`, `create_hash_partition_of`, and `attach_hash_partition` methods provide support for Hash partitions
+* `create_default_partition_of` and `attach_default_partition` allows adding of default partitions to range and list partitioned tables
+#### Full support for Subpartitioning
+* `create_x_partition_of` methods now support `partition_type` and `partition_key`, which may be supplied to create
+  a partitioned child table.
+    * Use `create_x_partition_of` with the child table name to add a partition to your subpartition
+    * Template tables are supported in that nested subpartitions will inherit from the top-level ancestor's template table, if found
+* The `partitions` command now accepts an `include_subpartitions:` option which defaults to false for backward compatibility
+    * Use `config.include_subpartitions_in_partition_list = true` to override the default
+#### `add_index_on_all_partitions`
+* Use this new adapter method in migrations to add an index on all partitions and subpartitions automatically
+* This method supports `algorithm: :concurrently` to perform uptime operations, so even when using Postgres 11+ it is needed to avoid table locks.
+* If you have many partitions, use the optional `in_threads:` option to parallelize index creation via the `parallel` gem
+#### Minor enhancements
+* Added adapter methods `partitions_for_table_name`, `parent_for_table_name`, and `table_partitioned?` to assist automating
+partition management, especially where subpartitions are involved
+  

--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ These methods are available in migrations as well as `ActiveRecord::Base#connect
   - Required args: `table_name`, `include_subpartitions:` (true or false)
 - `parent_for_table_name`
   - Fetch the parent table for a partition
+  - Required args: `table_name`
   - Pass optional `traverse: true` to return the top-level table in the hierarchy (for subpartitions)
   - Returns `nil` if the table is not a partition / has no parent
+- `table_partitioned?`
+  - Returns true if the table is partitioned (false for non-partitioned tables and partitions themselves)
+  - Required args: `table_name`
 - `add_index_on_all_partitions`
   - Recursively add an index to all partitions and subpartitions of `table_name` using Postgres's ADD INDEX CONCURRENTLY
     algorithm which adds the index in a non-blocking manner.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ These values can be accessed and set via `PgParty.config` and `PgParty.configure
 - `schema_exclude_partitions`
   - Whether to exclude child partitions in `rake db:structure:dump`
   - Default: `true`
+- `create_template_tables`
+  - Whether to create template tables by default. Use the `template:` option when creating partitioned tables to override this default.
+  - Default: `true`
+- `create_with_primary_key`
+  - Whether to add primary key constraints to partitioned (parent) tables by default.
+    * This is not supported for Postgres 10 but is recommended for Postgres 11
+    * Primary key constraints must include all partition keys, for example: `primary_key: [:id, :created_at], partition_key: :created_at`
+    * Partition keys cannot use expressions
+    * Can be overridden via the `create_with_primary_key:` option when creating partitioned tables
+  - Default: `false`
+- `include_subpartitions_in_partition_list`
+  - Whether to include nested subpartitions in the result of `YourModelClass.partiton_list` mby default.
+    You can always pass the `include_subpartitions:` option to override this.
+  - Default: `false` (for backward compatibility)
 
 Note that caching is done in-memory for each process of an application. Attaching / detaching partitions _will_ clear the cache, but only for the process that initiated the request. For multi-process web servers, it is recommended to use a TTL or disable caching entirely.
 
@@ -71,6 +85,10 @@ Note that caching is done in-memory for each process of an application. Attachin
 PgParty.configure do |c|
   c.caching_ttl = 60
   c.schema_exclude_partitions = false
+  c.include_subpartitions_in_partition_list = true
+  # Postgres 11+ users starting fresh may want to use below options
+  c.create_template_tables = false
+  c.create_with_primary_key = true
 end
 ```
 
@@ -88,25 +106,59 @@ These methods are available in migrations as well as `ActiveRecord::Base#connect
 - `create_list_partition`
   - Create partitioned table using the _list_ partitioning method
   - Required args: `table_name`, `partition_key:`
+- `create_hash_partition` (Postgres 11+)
+  - Create partitioned table using the _hash_ partitioning method
+  - Required args: `table_name`, `partition_key:`
 - `create_range_partition_of`
   - Create partition in _range_ partitioned table with partition key between _range_ of values
   - Required args: `table_name`, `start_range:`, `end_range:`
+  - Create a subpartition by specifying a `partition_type:` of `:range`, `:list`, or `:hash` and a `partition_key:`
 - `create_list_partition_of`
   - Create partition in _list_ partitioned table with partition key in _list_ of values
   - Required args: `table_name`, `values:`
+  - Create a subpartition by specifying a `partition_type:` of `:range`, `:list`, or `:hash` and a `partition_key:`
+- `create_hash_partition_of` (Postgres 11+)
+  - Create partition in _hash_ partitioned table for partition keys with hashed values having a specific remainder
+  - Required args: `table_name`, `modulus:`, `remainder`
+  - Create a subpartition by specifying a `partition_type:` of `:range`, `:list`, or `:hash` and a `partition_key:`
+  - Note that all partitions in a _hash_ partitioned table should have the same modulus. See [Examples](#examples) for more info.
+- `create_default_partition_of` (Postgres 11+)
+  - Create a default partition for values not falling in the range or list constraints of any other partitions
+  - Required args: `table_name`
 - `attach_range_partition`
   - Attach existing table to _range_ partitioned table with partition key between _range_ of values
   - Required args: `parent_table_name`, `child_table_name`, `start_range:`, `end_range:`
 - `attach_list_partition`
   - Attach existing table to _list_ partitioned table with partition key in _list_ of values
   - Required args: `parent_table_name`, `child_table_name`, `values:`
+- `attach_hash_partition` (Postgres 11+)
+  - Attach existing table to _hash_ partitioned table with partition key hashed values having a specific remainder
+  - Required args: `parent_table_name`, `child_table_name`, `modulus:`, `remainder`
+- `attach_default_partition` (Postgres 11+)
+  - Attach existing table as the _default_ partition
+  - Required args: `parent_table_name`, `child_table_name`
 - `detach_partition`
   - Detach partition from both _range and list_ partitioned tables
   - Required args: `parent_table_name`, `child_table_name`
 - `create_table_like`
   - Clone _any_ existing table
   - Required args: `table_name`, `new_table_name`
-
+- `partitions_for_table_name`
+  - List all attached partitions for a given table
+  - Required args: `table_name`, `include_subpartitions:` (true or false)
+- `parent_for_table_name`
+  - Fetch the parent table for a partition
+  - Pass optional `traverse: true` to return the top-level table in the hierarchy (for subpartitions)
+  - Returns `nil` if the table is not a partition / has no parent
+- `add_index_on_all_partitions`
+  - Recursively add an index to all partitions and subpartitions of `table_name` using Postgres's ADD INDEX CONCURRENTLY
+    algorithm which adds the index in a non-blocking manner.
+  - Required args: `table_name`, `column_name` (all `add_index` arguments are supported)
+  - Use the `in_threads:` option to add indexes in parallel threads when there are many partitions. A value of 2 to 4
+    may be reasonable for tables with many large partitions and hosts with 4+ CPUs/cores.
+  - Use `disable_ddl_transaction!` in your migration to disable transactions when using this command with `in_threads:`
+    or `algorithm: :concurrently`.
+    
 #### Examples
 
 Create _range_ partitioned table on `created_at::date` with two partitions:
@@ -157,20 +209,130 @@ class CreateSomeListRecord < ActiveRecord::Migration[5.1]
      create_list_partition_of \
        :some_list_records,
        values: 101..200
+    
+    # default partition support is available in Postgres 11 or higher
+     create_default_partition_of \
+       :some_list_records
   end
 end
 ```
 
+Create _hash_ partitioned table on `id` with two partitions (Postgres 11+ required):
+  * A hash partition can be used to spread keys evenly(ish) across partitions
+  * `modulus:` should always equal the total number of partitions planned for the table
+  * `remainder:` is an integer which should be in the range of 0 to modulus-1
+
+```ruby
+class CreateSomeHashRecord < ActiveRecord::Migration[5.1]
+  def up
+    # symbol is used for partition keys referring to individual columns
+    # create_with_primary_key: true, template: false on Postgres 11 will rely on PostgreSQL's native partition schema
+    # management vs this gem's template tables
+    create_hash_partition :some_hash_records, partition_key: :id, create_with_primary_key: true, template: false do |t|
+      t.text :some_value
+      t.timestamps
+    end
+
+    # without name argument, child partition created as "some_list_records_<hash>"
+    create_hash_partition_of \
+      :some_hash_records,
+      modulus: 2,
+      remainder: 0
+
+    # without name argument, child partition created as "some_list_records_<hash>"
+    create_hash_partition_of \
+      :some_hash_records,
+      modulus: 2,
+      remainder: 1
+  end
+end
+```
+
+Advanced example with subpartitioning: Create _list_ partitioned table on `id` subpartitioned by _range_ on `created_at`
+with default partitions
+* We can use Postgres 11's support for primary keys vs template tables, using the composite primary key `[:id, :created_at]`
+  to ensure all partition keys are present in the primary key
+* Default partitions are only supported in Postgres 11+
+
+```ruby
+class CreateSomeListSubpartitionedRecord < ActiveRecord::Migration[5.1]
+  def up
+    # when specifying a composite primary key, the primary keys must be specified as columns
+    create_list_partition \
+      :some_list_subpartitioned_records,
+      partition_key: [:id],
+      primary_key: [:id, :created_at],
+      template: false,
+      create_with_primary_key: true do |t|
+
+      t.integer :id
+      t.text :some_value
+      t.timestamps
+    end
+
+    create_default_partition_of \
+      :some_list_subpartitioned_records,
+      name: :some_list_subpartitioned_records_default,
+      partition_type: :range,
+      partition_key: :created_at
+
+    create_range_partition_of \
+      :some_list_subpartitioned_records_default,
+      name: :some_list_subpartitioned_records_default_2019,
+      start_range: '2019-01-01',
+      end_range: '2019-12-31T23:59:59'
+    
+    create_default_partition_of \
+      :some_list_subpartitioned_records_default
+
+    create_list_partition_of \
+      :some_list_subpartitioned_records,
+      name: :some_list_subpartitioned_records_1,
+      values: 1..100,
+      partition_type: :range,
+      partition_key: :created_at
+  
+    create_range_partition_of \
+      :some_list_subpartitioned_records_1,
+      name: :some_list_subpartitioned_records_1_2019,
+      start_range: '2019-01-01',
+      end_range: '2019-12-31T23:59:59'
+
+    create_default_partition_of
+      :some_list_subpartitioned_records_1
+
+     create_list_partition_of \
+       :some_list_subpartitioned_records,
+       name: :some_list_subpartitioned_records_2,
+       values: 101..200,
+       partition_type: :range,
+       partition_key: :created_at
+
+    create_range_partition_of \
+      :some_list_subpartitioned_records_2,
+      name: :some_list_subpartitioned_records_2_2019,
+      start_range: '2019-01-01',
+      end_range: '2019-12-31T23:59:59'
+
+    create_default_partition_of \
+      :some_list_subpartitioned_records_2
+  end
+end
+```
+
+#### Template Tables
 Unfortunately, PostgreSQL 10 doesn't support indexes on partitioned tables.
 However, individual _partitions_ can have indexes.
 To avoid explicit index creation for _every_ new partition, we've introduced the idea of template tables.
 For every call to `create_list_partition` and `create_range_partition`, a clone `<table_name>_template` is created.
 Indexes, constraints, etc. created on the template table will propagate to new partitions in calls to `create_list_partition_of` and `create_range_partition_of`:
+* Subpartitions will correctly clone from template tables if a template table exists for the top-level ancestor
+* When using Postgres 11 or higher, you may wish to disable template tables and use the native features instead, see [Configuration](#configuration)
 
 ```ruby
 class CreateSomeListRecord < ActiveRecord::Migration[5.1]
   def up
-    # template table creation is enabled by default - use "template: false" to opt-out
+    # template table creation is enabled by default - use "template: false" or the config option to opt-out
     create_list_partition :some_list_records, partition_key: :id do |t|
       t.integer :some_foreign_id
       t.text :some_value
@@ -192,6 +354,8 @@ class CreateSomeListRecord < ActiveRecord::Migration[5.1]
   end
 end
 ```
+
+#### Attaching Existing Tables as Partitions
 
 Attach an existing table to a _range_ partitioned table:
 
@@ -220,12 +384,51 @@ class AttachListPartition < ActiveRecord::Migration[5.1]
 end
 ```
 
+Attach an existing table to a _hash_ partitioned table:
+
+```ruby
+class AttachHashPartition < ActiveRecord::Migration[5.1]
+  def up
+    attach_hash_partition \
+      :some_hash_records,
+      :some_existing_table,
+      modulus: 2,
+      remainder: 1
+  end
+end
+```
+
 Detach a partition from any partitioned table:
 
 ```ruby
 class DetachPartition < ActiveRecord::Migration[5.1]
   def up
     detach_partition :parent_table, :child_table
+  end
+end
+```
+
+#### Safely cascading `add_index` commands
+Postgres 11+ will automatically cascade CREATE INDEX operations to partitions and subpartitions, however
+CREATE INDEX CONCURRENTLY is not supported, meaning table locks will be taken on each table while the new index is built.
+Postgres 10 provides no way to cascade index creation natively.
+* The `add_index_on_all_partitions` method solves for these limitations by recursively creating the specified
+  index on all partitions and subpartitions. Index names on individual partitions will include a hash suffix to avoid conflicts.
+* On Postgres 11+, the created indices are correctly attached to an index on the parent table
+* On Postgres 10, if you are using [Template Tables](#template-tables-for-postgres-10), you will want to add the index to the template table separately.
+* This command can also be used on subpartitions to cascade targeted indices starting at one level of the table hierarchy
+
+```ruby
+class AddSomeValueIndexToSomeListRecord < ActiveRecord::Migration[5.1]
+  # add_index_on_all_partitions with in_threads option may not be used within a transaction
+  # (also, algorithm: :concurrently cannot be used within a transaction)
+  disable_ddl_transaction!
+
+  def up
+    add_index :some_records_template, :some_value # Only if using Postgres 10 with template tables
+
+    # Pass the `in_threads:` option to create indices in parallel across multiple Postgres connections
+    add_index_on_all_partitions :some_records, :some_value, algorithm: :concurrently, in_threads: 4
   end
 end
 ```
@@ -250,12 +453,15 @@ Class methods available to _all_ ActiveRecord models:
 - `list_partition_by`
   - Configure a model backed by a _list_ partitioned table
   - Required arg: `key` (partition key column) or block returning partition key expression
+- `hash_partition_by`
+  - Configure a model backed by a _hash_ partitioned table
+  - Required arg: `key` (partition key column) or block returning partition key expression
 
 Class methods available to both _range and list_ partitioned models:
 
 - `partitions`
   - Retrieve a list of currently attached partitions
-  - No arguments
+  - Optional `include_subpartitions:` argument to include all subpartitions in the returned list
 - `in_partition`
   - Retrieve an ActiveRecord model scoped to an individual partition
   - Required arg: `child_table_name`
@@ -280,6 +486,16 @@ Class methods available to _list_ partitioned models:
 - `partition_key_in`
   - Query for records where partition key in _list_ of values
   - Required arg: list of `values`
+  
+
+Class methods available to _hash_ partitioned models:
+
+- `create_partition`
+  - Dynamically create new partition with hashed partition key divided by _modulus_ equals _remainder_
+  - Required arg: `modulus:`, `remainder:`
+- `partition_key_in`
+  - Query for records where partition key in _list_ of values (method operates the same as for _list_ partitions above)
+  - Required arg: list of `values`
 
 #### Examples
 
@@ -301,6 +517,15 @@ class SomeListRecord < ApplicationRecord
 end
 ```
 
+Configure model backed by a _hash_ partitioned table to get access to the methods described above:
+
+```ruby
+class SomeHashRecord < ApplicationRecord
+  # symbol is used for partition keys referring to individual columns
+  hash_partition_by :id
+end
+```
+
 Dynamically create new partition from _range_ partitioned model:
 
 ```ruby
@@ -315,19 +540,26 @@ Dynamically create new partition from _list_ partitioned model:
 SomeListRecord.create_partition(values: 200..300)
 ```
 
+Dynamically create new partition from _hash_ partitioned model:
+
+```ruby
+# additional options include: "name:" and "primary_key:"
+SomeHashRecord.create_partition(modulus: 2, remainder: 1)
+```
+
 For _range_ partitioned model, query for records where partition key in _range_ of values:
 
 ```ruby
 SomeRangeRecord.partition_key_in("2019-06-08", "2019-06-10")
 ```
 
-For _list_ partitioned model, query for records where partition key in _list_ of values:
+For _list_ and _hash_ partitioned models, query for records where partition key in _list_ of values:
 
 ```ruby
 SomeListRecord.partition_key_in(1, 2, 3, 4)
 ```
 
-For both _range and list_ partitioned models, query for records matching partition key:
+For all partitioned models, query for records matching partition key:
 
 ```ruby
 SomeRangeRecord.partition_key_eq(Date.current)
@@ -335,15 +567,15 @@ SomeRangeRecord.partition_key_eq(Date.current)
 SomeListRecord.partition_key_eq(100)
 ```
 
-For both _range and list_ partitioned models, retrieve currently attached partitions:
+For all partitioned models, retrieve currently attached partitions:
 
 ```ruby
 SomeRangeRecord.partitions
 
-SomeListRecord.partitions
+SomeListRecord.partitions(include_subpartitions: true) # Include nested subpartitions
 ```
 
-For both _range and list_ partitioned models, retrieve ActiveRecord model scoped to individual partition:
+For both all partitioned models, retrieve ActiveRecord model scoped to individual partition:
 
 ```ruby
 SomeRangeRecord.in_partition(:some_range_records_partition_name)

--- a/lib/pg_party/adapter/abstract_methods.rb
+++ b/lib/pg_party/adapter/abstract_methods.rb
@@ -66,6 +66,10 @@ module PgParty
       def add_index_on_all_partitions(*)
         raise "#add_index_on_all_partitions is not implemented"
       end
+
+      def table_partitioned?(*)
+        raise "#table_partitioned? is not implemented"
+      end
     end
   end
 end

--- a/lib/pg_party/adapter/abstract_methods.rb
+++ b/lib/pg_party/adapter/abstract_methods.rb
@@ -11,12 +11,24 @@ module PgParty
         raise "#create_list_partition is not implemented"
       end
 
+      def create_hash_partition(*)
+        raise "#create_hash_partition is not implemented"
+      end
+
       def create_range_partition_of(*)
         raise "#create_range_partition_of is not implemented"
       end
 
       def create_list_partition_of(*)
         raise "#create_list_partition_of is not implemented"
+      end
+
+      def create_hash_partition_of(*)
+        raise "#create_hash_partition_of is not implemented"
+      end
+
+      def create_default_partition_of(*)
+        raise "#create_default_partition_of is not implemented"
       end
 
       def create_table_like(*)
@@ -31,8 +43,28 @@ module PgParty
         raise "#attach_list_partition is not implemented"
       end
 
+      def attach_hash_partition(*)
+        raise "#attach_hash_partition is not implemented"
+      end
+
+      def attach_default_partition(*)
+        raise "#attach_default_partition is not implemented"
+      end
+
       def detach_partition(*)
         raise "#detach_partition is not implemented"
+      end
+
+      def parent_for_table_name(*)
+        raise "#parent_for_table_name is not implemented"
+      end
+
+      def partitions_for_table_name(*)
+        raise "#partitions_for_table_name is not implemented"
+      end
+
+      def add_index_on_all_partitions(*)
+        raise "#add_index_on_all_partitions is not implemented"
       end
     end
   end

--- a/lib/pg_party/adapter/postgresql_methods.rb
+++ b/lib/pg_party/adapter/postgresql_methods.rb
@@ -69,6 +69,10 @@ module PgParty
       ruby2_keywords def add_index_on_all_partitions(*args)
         PgParty::AdapterDecorator.new(self).add_index_on_all_partitions(*args)
       end
+
+      ruby2_keywords def table_partitioned?(*args)
+        PgParty::AdapterDecorator.new(self).table_partitioned?(*args)
+      end
     end
   end
 end

--- a/lib/pg_party/adapter/postgresql_methods.rb
+++ b/lib/pg_party/adapter/postgresql_methods.rb
@@ -14,12 +14,24 @@ module PgParty
         PgParty::AdapterDecorator.new(self).create_list_partition(*args, &blk)
       end
 
+      ruby2_keywords def create_hash_partition(*args, &blk)
+        PgParty::AdapterDecorator.new(self).create_hash_partition(*args, &blk)
+      end
+
       ruby2_keywords def create_range_partition_of(*args)
         PgParty::AdapterDecorator.new(self).create_range_partition_of(*args)
       end
 
       ruby2_keywords def create_list_partition_of(*args)
         PgParty::AdapterDecorator.new(self).create_list_partition_of(*args)
+      end
+
+      ruby2_keywords def create_hash_partition_of(*args)
+        PgParty::AdapterDecorator.new(self).create_hash_partition_of(*args)
+      end
+
+      ruby2_keywords def create_default_partition_of(*args)
+        PgParty::AdapterDecorator.new(self).create_default_partition_of(*args)
       end
 
       ruby2_keywords def create_table_like(*args)
@@ -34,8 +46,28 @@ module PgParty
         PgParty::AdapterDecorator.new(self).attach_list_partition(*args)
       end
 
+      ruby2_keywords def attach_hash_partition(*args)
+        PgParty::AdapterDecorator.new(self).attach_hash_partition(*args)
+      end
+
+      ruby2_keywords def attach_default_partition(*args)
+        PgParty::AdapterDecorator.new(self).attach_default_partition(*args)
+      end
+
       ruby2_keywords def detach_partition(*args)
         PgParty::AdapterDecorator.new(self).detach_partition(*args)
+      end
+
+      ruby2_keywords def partitions_for_table_name(*args)
+        PgParty::AdapterDecorator.new(self).partitions_for_table_name(*args)
+      end
+
+      ruby2_keywords def parent_for_table_name(*args)
+        PgParty::AdapterDecorator.new(self).parent_for_table_name(*args)
+      end
+
+      ruby2_keywords def add_index_on_all_partitions(*args)
+        PgParty::AdapterDecorator.new(self).add_index_on_all_partitions(*args)
       end
     end
   end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -297,13 +297,13 @@ module PgParty
     end
 
     def attach_child_index(child, parent)
-      return unless postgres_11_plus?
+      return unless postgres_major_version >= 11
 
       execute "ALTER INDEX #{quote_column_name(parent)} ATTACH PARTITION #{quote_column_name(child)}"
     end
 
     def add_index_only(table_name, type:, name:, using:, columns:, options:)
-      return unless postgres_11_plus?
+      return unless postgres_major_version >= 11
 
       execute "CREATE #{type} INDEX #{quote_column_name(name)} ON ONLY "\
               "#{quote_table_name(table_name)} #{using} (#{columns})#{options}"
@@ -410,7 +410,7 @@ module PgParty
 
     def validate_supported_partition_type!(partition_type)
       if (sym = partition_type.to_s.downcase.to_sym) && sym.in?(SUPPORTED_PARTITION_TYPES)
-        return if sym != :hash || postgres_11_plus?
+        return if sym != :hash || postgres_major_version >= 11
 
         raise NotImplementedError, 'Hash partitions are only available in Postgres 11 or higher'
       end
@@ -419,17 +419,17 @@ module PgParty
     end
 
     def validate_default_partition_support!
-      return if postgres_11_plus?
+      return if postgres_major_version >= 11
 
       raise NotImplementedError, 'Default partitions are only available in Postgres 11 or higher'
     end
 
     def supports_partitions?
-      __getobj__.send(:postgresql_version) >= 100000
+      postgres_major_version >= 10
     end
 
-    def postgres_11_plus?
-      __getobj__.send(:postgresql_version) >= 110000
+    def postgres_major_version
+      __getobj__.send(:postgresql_version)/10000
     end
   end
 end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "digest"
+require 'parallel'
 
 module PgParty
   class AdapterDecorator < SimpleDelegator
+    SUPPORTED_PARTITION_TYPES = %i[range list hash].freeze
+
     def initialize(adapter)
       super(adapter)
 
@@ -18,6 +21,10 @@ module PgParty
       create_partition(table_name, :list, partition_key, **options, &blk)
     end
 
+    def create_hash_partition(table_name, partition_key:, **options, &blk)
+      create_partition(table_name, :hash, partition_key, **options, &blk)
+    end
+
     def create_range_partition_of(table_name, start_range:, end_range:, **options)
       create_partition_of(table_name, range_constraint_clause(start_range, end_range), **options)
     end
@@ -26,17 +33,42 @@ module PgParty
       create_partition_of(table_name, list_constraint_clause(values), **options)
     end
 
-    def create_table_like(table_name, new_table_name, **options)
-      primary_key = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+    def create_hash_partition_of(table_name, modulus:, remainder:, **options)
+      create_partition_of(table_name, hash_constraint_clause(modulus, remainder), **options)
+    end
 
-      validate_primary_key(primary_key)
+    def create_default_partition_of(table_name, **options)
+      create_partition_of(table_name, nil, default_partition: true, **options)
+    end
+
+    def create_table_like(table_name, new_table_name, **options)
+      primary_key           = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+      partition_key         = options.fetch(:partition_key, nil)
+      partition_type        = options.fetch(:partition_type, nil)
+      create_with_pks       = options.fetch(
+                                :create_with_primary_key,
+                                PgParty.config.create_with_primary_key
+                              )
+
+      validate_primary_key(primary_key) unless create_with_pks
+      if partition_type
+        validate_supported_partition_type!(partition_type)
+        raise ArgumentError, '`partition_key` is required when specifying a partition_type' unless partition_key
+      end
+
+      like_option = if !partition_type || create_with_pks
+                      'INCLUDING ALL'
+                    else
+                      'INCLUDING ALL EXCLUDING INDEXES'
+                    end
 
       execute(<<-SQL)
         CREATE TABLE #{quote_table_name(new_table_name)} (
-          LIKE #{quote_table_name(table_name)} INCLUDING ALL
-        )
+          LIKE #{quote_table_name(table_name)} #{like_option}
+        ) #{partition_type ? partition_by_clause(partition_type, partition_key) : nil}
       SQL
 
+      return if partition_type
       return if !primary_key
       return if has_primary_key?(new_table_name)
 
@@ -54,6 +86,20 @@ module PgParty
       attach_partition(parent_table_name, child_table_name, list_constraint_clause(values))
     end
 
+    def attach_hash_partition(parent_table_name, child_table_name, modulus:, remainder:)
+      attach_partition(parent_table_name, child_table_name, hash_constraint_clause(modulus, remainder))
+    end
+
+    def attach_default_partition(parent_table_name, child_table_name)
+      execute(<<-SQL)
+        ALTER TABLE #{quote_table_name(parent_table_name)}
+        ATTACH PARTITION #{quote_table_name(child_table_name)}
+        DEFAULT
+      SQL
+
+      PgParty.cache.clear!
+    end
+
     def detach_partition(parent_table_name, child_table_name)
       execute(<<-SQL)
         ALTER TABLE #{quote_table_name(parent_table_name)}
@@ -63,23 +109,91 @@ module PgParty
       PgParty.cache.clear!
     end
 
+    def partitions_for_table_name(table_name, include_subpartitions:, _accumulator: [])
+      select_values(%[
+          SELECT pg_inherits.inhrelid::regclass::text
+          FROM pg_tables
+          INNER JOIN pg_inherits
+            ON pg_tables.tablename::regclass = pg_inherits.inhparent::regclass
+          WHERE pg_tables.tablename = #{quote(table_name)}
+                    ]).each_with_object(_accumulator) do |partition, acc|
+        acc << partition
+        next unless include_subpartitions
+
+        partitions_for_table_name(partition, include_subpartitions: true, _accumulator: acc)
+      end
+    end
+
+    def parent_for_table_name(table_name, traverse: false)
+      parent = select_values(%[
+          SELECT pg_inherits.inhparent::regclass::text
+          FROM pg_tables
+          INNER JOIN pg_inherits
+            ON pg_tables.tablename::regclass = pg_inherits.inhrelid::regclass
+          WHERE pg_tables.tablename = #{quote(table_name)}
+      ]).first
+      return parent if parent.nil? || !traverse
+
+      while (parents_parent = parent_for_table_name(parent)) do
+        parent = parents_parent
+      end
+
+      parent
+    end
+
+    def add_index_on_all_partitions(table_name, column_name, in_threads: nil, **options)
+      if in_threads && open_transactions > 0
+        raise ArgumentError, '`in_threads:` cannot be used within a transaction. If running in a migration, use '\
+              '`disable_ddl_transaction!` and break out this operation into its own migration.'
+      end
+
+      index_name, index_type, index_columns, index_options, algorithm, using = add_index_options(
+          table_name, column_name, options
+        )
+
+      # Postgres limits index name to 63 bytes (characters). We will use 8 characters for a `_random_suffix`
+      # on partitions to ensure no conflicts, leaving 55 chars for the specified index name
+      raise ArgumentError 'index name is too long - must be 55 characters or fewer' if index_name.length > 55
+
+      recursive_add_index(
+        table_name: table_name,
+        index_name: index_name,
+        index_type: index_type,
+        index_columns: index_columns,
+        index_options: index_options,
+        algorithm: algorithm,
+        using: using,
+        in_threads: in_threads
+      )
+    end
+
     private
 
     def create_partition(table_name, type, partition_key, **options)
-      modified_options = options.except(:id, :primary_key, :template)
-      template         = options.fetch(:template, true)
-      id               = options.fetch(:id, :bigserial)
-      primary_key      = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+      modified_options      = options.except(:id, :primary_key, :template, :create_with_primary_key)
+      template              = options.fetch(:template, PgParty.config.create_template_tables)
+      id                    = options.fetch(:id, :bigserial)
+      primary_key           = options.fetch(:primary_key) { calculate_primary_key(table_name) }
+      create_with_pks       = options.fetch(
+                                :create_with_primary_key,
+                                PgParty.config.create_with_primary_key
+                              )
 
-      validate_primary_key(primary_key)
+      validate_supported_partition_type!(type)
 
-      modified_options[:id]      = false
-      modified_options[:options] = "PARTITION BY #{type.to_s.upcase} (#{quote_partition_key(partition_key)})"
+      if create_with_pks
+        modified_options[:primary_key] = primary_key
+        modified_options[:id] = id
+      else
+        validate_primary_key(primary_key)
+        modified_options[:id] = false
+      end
+      modified_options[:options] = partition_by_clause(type, partition_key)
 
       create_table(table_name, modified_options) do |td|
-        if id == :uuid
+        if !modified_options[:id] && id == :uuid
           td.column(primary_key, id, null: false, default: uuid_function)
-        elsif id
+        elsif !modified_options[:id] && id
           td.column(primary_key, id, null: false)
         end
 
@@ -87,11 +201,16 @@ module PgParty
       end
 
       # Rails 4 has a bug where uuid columns are always nullable
-      change_column_null(table_name, primary_key, false) if id == :uuid
+      change_column_null(table_name, primary_key, false) if !modified_options[:id] && id == :uuid
 
       return unless template
 
-      create_table_like(table_name, template_table_name(table_name), primary_key: id && primary_key)
+      create_table_like(
+        table_name,
+        template_table_name(table_name),
+        primary_key: id && primary_key,
+        create_with_primary_key: create_with_pks
+      )
     end
 
     def create_partition_of(table_name, constraint_clause, **options)
@@ -99,13 +218,21 @@ module PgParty
       primary_key         = options.fetch(:primary_key) { calculate_primary_key(table_name) }
       template_table_name = template_table_name(table_name)
 
+      validate_default_partition_support! if options[:default_partition]
+
       if schema_cache.data_source_exists?(template_table_name)
-        create_table_like(template_table_name, child_table_name, primary_key: false)
+        create_table_like(template_table_name, child_table_name, primary_key: false,
+                          partition_type: options[:partition_type], partition_key: options[:partition_key])
       else
-        create_table_like(table_name, child_table_name, primary_key: primary_key)
+        create_table_like(table_name, child_table_name, primary_key: primary_key,
+                          partition_type: options[:partition_type], partition_key: options[:partition_key])
       end
 
-      attach_partition(table_name, child_table_name, constraint_clause)
+      if options[:default_partition]
+        attach_default_partition(table_name, child_table_name)
+      else
+        attach_partition(table_name, child_table_name, constraint_clause)
+      end
 
       child_table_name
     end
@@ -118,6 +245,72 @@ module PgParty
       SQL
 
       PgParty.cache.clear!
+    end
+
+    def recursive_add_index(table_name:, index_name:, index_type:, index_columns:, index_options:, using:, algorithm:,
+                            in_threads: nil, _parent_index_name: nil, _created_index_names: [])
+      partitions = partitions_for_table_name(table_name, include_subpartitions: false)
+      updated_name = _created_index_names.empty? ? index_name : generate_index_name(index_name, table_name)
+
+      # If this is a partitioned table, add index ONLY on this table.
+      if table_partitioned?(table_name)
+        if postgres_11_plus?
+          execute "CREATE #{index_type} INDEX #{quote_column_name(updated_name)} ON ONLY "\
+                  "#{quote_table_name(table_name)} #{using} (#{index_columns})#{index_options}"
+        end
+        _created_index_names << updated_name
+
+        if partitions.any? && in_threads && in_threads > 1
+          Parallel.map(partitions, in_threads: in_threads) do |partition_name|
+            ActiveRecord::Base.connection_pool.with_connection do
+              recursive_add_index(
+                table_name: partition_name,
+                index_name: index_name,
+                index_type: index_type,
+                index_columns: index_columns,
+                index_options: index_options,
+                using: using,
+                algorithm: algorithm,
+                _parent_index_name: updated_name,
+                _created_index_names: _created_index_names
+              )
+            end
+          end
+        else
+          partitions.each do |partition_name|
+            recursive_add_index(
+              table_name: partition_name,
+              index_name: index_name,
+              index_type: index_type,
+              index_columns: index_columns,
+              index_options: index_options,
+              using: using,
+              algorithm: algorithm,
+              _parent_index_name: updated_name,
+              _created_index_names: _created_index_names
+            )
+          end
+        end
+      else
+        _created_index_names << updated_name # Track as created before execution of concurrent index command
+        execute "CREATE #{index_type} INDEX #{algorithm} #{quote_column_name(updated_name)} ON "\
+                "#{quote_table_name(table_name)} #{using} (#{index_columns})#{index_options}"
+      end
+
+      if _parent_index_name && postgres_11_plus?
+        execute "ALTER INDEX #{quote_column_name(_parent_index_name)} "\
+                "ATTACH PARTITION #{quote_column_name(updated_name)}"
+      end
+
+      return true if index_valid?(updated_name)
+
+      raise 'index creation failed - an index was marked invalid'
+    rescue => e
+      # Clean up any indexes created so this command can be retried later
+      _created_index_names.each do |created_index|
+        execute "DROP INDEX IF EXISTS #{quote_column_name(created_index)}"
+      end
+      raise e
     end
 
     # Rails 5.2 now returns boolean literals
@@ -157,15 +350,23 @@ module PgParty
     end
 
     def template_table_name(table_name)
-      "#{table_name}_template"
+      "#{parent_for_table_name(table_name, traverse: true) || table_name}_template"
     end
 
     def range_constraint_clause(start_range, end_range)
       "FROM (#{quote_collection(start_range)}) TO (#{quote_collection(end_range)})"
     end
 
+    def hash_constraint_clause(modulus, remainder)
+      "WITH (MODULUS #{modulus.to_i}, REMAINDER #{remainder.to_i})"
+    end
+
     def list_constraint_clause(values)
       "IN (#{quote_collection(values.try(:to_a) || values)})"
+    end
+
+    def partition_by_clause(type, partition_key)
+      "PARTITION BY #{type.to_s.upcase} (#{quote_partition_key(partition_key)})"
     end
 
     def uuid_function
@@ -173,11 +374,53 @@ module PgParty
     end
 
     def hashed_table_name(table_name, key)
-      "#{table_name}_#{Digest::MD5.hexdigest(key)[0..6]}"
+      return "#{table_name}_#{Digest::MD5.hexdigest(key)[0..6]}" if key
+
+      # use _default suffix for default partitions (without a constraint clause)
+      "#{table_name}_default"
+    end
+
+    def index_valid?(index_name)
+      select_values(
+        "SELECT relname FROM pg_class, pg_index WHERE pg_index.indisvalid = false AND "\
+          "pg_index.indexrelid = pg_class.oid AND relname = #{quote(index_name)}"
+      ).empty?
+    end
+
+    def table_partitioned?(table_name)
+      select_values(%[
+        SELECT relkind FROM pg_catalog.pg_class AS c
+        JOIN pg_catalog.pg_namespace AS ns ON c.relnamespace = ns.oid
+        WHERE relname = #{quote(table_name)} AND nspname = current_schema()
+      ]).first == 'p'
+    end
+
+    def generate_index_name(index_name, table_name)
+      "#{index_name}_#{Digest::MD5.hexdigest(table_name)[0..6]}"
+    end
+
+    def validate_supported_partition_type!(partition_type)
+      if (sym = partition_type.to_s.downcase.to_sym) && sym.in?(SUPPORTED_PARTITION_TYPES)
+        return if sym != :hash || postgres_11_plus?
+
+        raise NotImplementedError, 'Hash partitions are only available in Postgres 11 or higher'
+      end
+
+      raise ArgumentError, "Supported partition types are #{SUPPORTED_PARTITION_TYPES.join(', ')}"
+    end
+
+    def validate_default_partition_support!
+      return if postgres_11_plus?
+
+      raise NotImplementedError, 'Default partitions are only available in Postgres 11 or higher'
     end
 
     def supports_partitions?
       __getobj__.send(:postgresql_version) >= 100000
+    end
+
+    def postgres_11_plus?
+      __getobj__.send(:postgresql_version) >= 110000
     end
   end
 end

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -167,6 +167,14 @@ module PgParty
       )
     end
 
+    def table_partitioned?(table_name)
+      select_values(%[
+        SELECT relkind FROM pg_catalog.pg_class AS c
+        JOIN pg_catalog.pg_namespace AS ns ON c.relnamespace = ns.oid
+        WHERE relname = #{quote(table_name)} AND nspname = current_schema()
+      ]).first == 'p'
+    end
+
     private
 
     def create_partition(table_name, type, partition_key, **options)
@@ -385,14 +393,6 @@ module PgParty
         "SELECT relname FROM pg_class, pg_index WHERE pg_index.indisvalid = false AND "\
           "pg_index.indexrelid = pg_class.oid AND relname = #{quote(index_name)}"
       ).empty?
-    end
-
-    def table_partitioned?(table_name)
-      select_values(%[
-        SELECT relkind FROM pg_catalog.pg_class AS c
-        JOIN pg_catalog.pg_namespace AS ns ON c.relnamespace = ns.oid
-        WHERE relname = #{quote(table_name)} AND nspname = current_schema()
-      ]).first == 'p'
     end
 
     def generate_index_name(index_name, table_name)

--- a/lib/pg_party/cache.rb
+++ b/lib/pg_party/cache.rb
@@ -9,7 +9,7 @@ module PgParty
     def initialize
       # automatically initialize a new hash when
       # accessing an object id that doesn't exist
-      @store = Hash.new { |h, k| h[k] = { models: {}, partitions: nil } }
+      @store = Hash.new { |h, k| h[k] = { models: {}, partitions: nil, partitions_with_subpartitions: nil } }
     end
 
     def clear!
@@ -24,10 +24,11 @@ module PgParty
       LOCK.synchronize { fetch_value(@store[key][:models], child_table.to_sym, block) }
     end
 
-    def fetch_partitions(key, &block)
+    def fetch_partitions(key, include_subpartitions, &block)
       return block.call unless caching_enabled?
+      sub_key = include_subpartitions ? :partitions_with_subpartitions : :partitions
 
-      LOCK.synchronize { fetch_value(@store[key], :partitions, block) }
+      LOCK.synchronize { fetch_value(@store[key], sub_key, block) }
     end
 
     private

--- a/lib/pg_party/config.rb
+++ b/lib/pg_party/config.rb
@@ -5,12 +5,18 @@ module PgParty
     attr_accessor \
       :caching,
       :caching_ttl,
-      :schema_exclude_partitions
+      :schema_exclude_partitions,
+      :create_template_tables,
+      :create_with_primary_key,
+      :include_subpartitions_in_partition_list
 
     def initialize
       @caching = true
       @caching_ttl = -1
       @schema_exclude_partitions = true
+      @create_template_tables = true
+      @create_with_primary_key = false
+      @include_subpartitions_in_partition_list = false
     end
   end
 end

--- a/lib/pg_party/model/hash_methods.rb
+++ b/lib/pg_party/model/hash_methods.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "pg_party/model_decorator"
+require "ruby2_keywords"
+
+module PgParty
+  module Model
+    module HashMethods
+      ruby2_keywords def create_partition(*args)
+        PgParty::ModelDecorator.new(self).create_hash_partition(*args)
+      end
+
+      ruby2_keywords def partition_key_in(*args)
+        PgParty::ModelDecorator.new(self).hash_partition_key_in(*args)
+      end
+    end
+  end
+end

--- a/lib/pg_party/model/list_methods.rb
+++ b/lib/pg_party/model/list_methods.rb
@@ -10,6 +10,10 @@ module PgParty
         PgParty::ModelDecorator.new(self).create_list_partition(*args)
       end
 
+      ruby2_keywords def create_default_partition(*args)
+        PgParty::ModelDecorator.new(self).create_default_partition(*args)
+      end
+
       ruby2_keywords def partition_key_in(*args)
         PgParty::ModelDecorator.new(self).list_partition_key_in(*args)
       end

--- a/lib/pg_party/model/methods.rb
+++ b/lib/pg_party/model/methods.rb
@@ -13,6 +13,10 @@ module PgParty
         PgParty::ModelInjector.new(self, *key, &blk).inject_list_methods
       end
 
+      def hash_partition_by(*key, &blk)
+        PgParty::ModelInjector.new(self, *key, &blk).inject_hash_methods
+      end
+
       def partitioned?
         try(:partition_key).present?
       end

--- a/lib/pg_party/model/range_methods.rb
+++ b/lib/pg_party/model/range_methods.rb
@@ -10,6 +10,10 @@ module PgParty
         PgParty::ModelDecorator.new(self).create_range_partition(*args)
       end
 
+      ruby2_keywords def create_default_partition(*args)
+        PgParty::ModelDecorator.new(self).create_default_partition(*args)
+      end
+
       ruby2_keywords def partition_key_in(*args)
         PgParty::ModelDecorator.new(self).range_partition_key_in(*args)
       end

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -9,7 +9,7 @@ module PgParty
         return base_class.primary_key if self != base_class
 
         partitions = partitions(include_subpartitions: true)
-        return get_primary_key(base_class.name) unless partitions.any?
+        return get_primary_key(base_class.name) if partitions.empty?
 
         first_partition = partitions.detect { |p| !connection.table_partitioned?(p) }
         raise 'No leaf partitions exist for this model. Create a partition to contain your data' unless first_partition

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -8,7 +8,10 @@ module PgParty
       def reset_primary_key
         if self != base_class
           base_class.primary_key
-        elsif partition_name = partitions.first
+        elsif (partitions = partitions(include_subpartitions: true)) && partitions.any?
+          partition_name = partitions.detect { |p| !connection.table_partitioned?(p) }
+          raise 'No child partitions exist for this model' unless partition_name
+
           in_partition(partition_name).get_primary_key(base_class.name)
         else
           get_primary_key(base_class.name)

--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -21,8 +21,8 @@ module PgParty
         connection.schema_cache.data_source_exists?(target_table)
       end
 
-      def partitions
-        PgParty::ModelDecorator.new(self).partitions
+      def partitions(*args)
+        PgParty::ModelDecorator.new(self).partitions(*args)
       end
 
       def in_partition(*args)

--- a/lib/pg_party/model_injector.rb
+++ b/lib/pg_party/model_injector.rb
@@ -20,6 +20,12 @@ module PgParty
       inject_methods_for(PgParty::Model::ListMethods)
     end
 
+    def inject_hash_methods
+      require "pg_party/model/hash_methods"
+
+      inject_methods_for(PgParty::Model::HashMethods)
+    end
+
     private
 
     def inject_methods_for(mod)

--- a/lib/pg_party/version.rb
+++ b/lib/pg_party/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PgParty
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/pg_party.gemspec
+++ b/pg_party.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord", ">= 5.0", "< 6.1"
   spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
+  spec.add_runtime_dependency "parallel"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "byebug", "~> 11.0"

--- a/pg_party.gemspec
+++ b/pg_party.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord", ">= 5.0", "< 6.1"
   spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
-  spec.add_runtime_dependency "parallel"
+  spec.add_runtime_dependency "parallel", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "byebug", "~> 11.0"

--- a/spec/adapter/abstract_methods_spec.rb
+++ b/spec/adapter/abstract_methods_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     end
   end
 
+  describe '#create_hash_partition' do
+    subject { adapter.create_hash_partition("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#create_hash_partition is not implemented")
+    end
+  end
+
   describe "#create_range_partition_of" do
     subject { adapter.create_range_partition_of("args") }
 
@@ -40,6 +48,22 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
 
     it "raises not implemented error" do
       expect { subject }.to raise_error(RuntimeError, "#create_list_partition_of is not implemented")
+    end
+  end
+
+  describe "#create_hash_partition_of" do
+    subject { adapter.create_hash_partition_of("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#create_hash_partition_of is not implemented")
+    end
+  end
+
+  describe "#create_default_partition_of" do
+    subject { adapter.create_default_partition_of("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#create_default_partition_of is not implemented")
     end
   end
 
@@ -67,11 +91,51 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
     end
   end
 
+  describe "#attach_hash_partition" do
+    subject { adapter.attach_hash_partition("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#attach_hash_partition is not implemented")
+    end
+  end
+
+  describe "#attach_default_partition" do
+    subject { adapter.attach_default_partition("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#attach_default_partition is not implemented")
+    end
+  end
+
   describe "#detach_partition" do
     subject { adapter.detach_partition("args") }
 
     it "raises not implemented error" do
       expect { subject }.to raise_error(RuntimeError, "#detach_partition is not implemented")
+    end
+  end
+
+  describe "#parent_for_table_name" do
+    subject { adapter.parent_for_table_name("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#parent_for_table_name is not implemented")
+    end
+  end
+
+  describe "#partitions_for_table_name" do
+    subject { adapter.partitions_for_table_name("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#partitions_for_table_name is not implemented")
+    end
+  end
+
+  describe "#add_index_on_all_partitions" do
+    subject { adapter.add_index_on_all_partitions("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#add_index_on_all_partitions is not implemented")
     end
   end
 end

--- a/spec/adapter/abstract_methods_spec.rb
+++ b/spec/adapter/abstract_methods_spec.rb
@@ -138,4 +138,12 @@ RSpec.describe PgParty::Adapter::AbstractMethods do
       expect { subject }.to raise_error(RuntimeError, "#add_index_on_all_partitions is not implemented")
     end
   end
+
+  describe "#table_partitioned?" do
+    subject { adapter.table_partitioned?("args") }
+
+    it "raises not implemented error" do
+      expect { subject }.to raise_error(RuntimeError, "#table_partitioned? is not implemented")
+    end
+  end
 end

--- a/spec/adapter/postgresql_methods_spec.rb
+++ b/spec/adapter/postgresql_methods_spec.rb
@@ -160,4 +160,14 @@ RSpec.describe PgParty::Adapter::PostgreSQLMethods do
       subject
     end
   end
+
+  describe "#table_partitioned?" do
+    subject { adapter.table_partitioned?(:table_name) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:table_partitioned?)
+                             .with(:table_name)
+      subject
+    end
+  end
 end

--- a/spec/adapter/postgresql_methods_spec.rb
+++ b/spec/adapter/postgresql_methods_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe PgParty::Adapter::PostgreSQLMethods do
     end
   end
 
+  describe "#create_hash_partition" do
+    subject { adapter.create_hash_partition(:parent, partition_key: :id) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:create_hash_partition).with(:parent, partition_key: :id)
+      subject
+    end
+  end
+
   describe "#create_range_partition_of" do
     subject { adapter.create_range_partition_of(:parent, start_range: 1, end_range: 10) }
 
@@ -48,6 +57,24 @@ RSpec.describe PgParty::Adapter::PostgreSQLMethods do
 
     it "delegates to decorator" do
       expect(decorator).to receive(:create_list_partition_of).with(:parent, values: [1, 2, 3])
+      subject
+    end
+  end
+
+  describe "#create_hash_partition_of" do
+    subject { adapter.create_hash_partition_of(:parent, modulus: 2, remainder: 0) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:create_hash_partition_of).with(:parent, modulus: 2, remainder: 0)
+      subject
+    end
+  end
+
+  describe "#create_default_partition_of" do
+    subject { adapter.create_default_partition_of(:parent) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:create_default_partition_of).with(:parent)
       subject
     end
   end
@@ -79,11 +106,57 @@ RSpec.describe PgParty::Adapter::PostgreSQLMethods do
     end
   end
 
+  describe "#attach_hash_partition" do
+    subject { adapter.attach_hash_partition(:parent, :child, modulus: 2, remainder: 0) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:attach_hash_partition).with(:parent, :child, modulus: 2, remainder: 0)
+      subject
+    end
+  end
+
+  describe "#attach_default_partition" do
+    subject { adapter.attach_default_partition(:parent, :child) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:attach_default_partition).with(:parent, :child)
+      subject
+    end
+  end
+
   describe "#detach_partition" do
     subject { adapter.detach_partition(:parent, :child) }
 
     it "delegates to decorator" do
       expect(decorator).to receive(:detach_partition).with(:parent, :child)
+      subject
+    end
+  end
+
+  describe "#parent_for_table_name" do
+    subject { adapter.parent_for_table_name(:table_name, traverse: true) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:parent_for_table_name).with(:table_name, traverse: true)
+      subject
+    end
+  end
+
+  describe "#partitions_for_table_name" do
+    subject { adapter.partitions_for_table_name(:table_name, include_subpartitions: true) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:partitions_for_table_name).with(:table_name, include_subpartitions: true)
+      subject
+    end
+  end
+
+  describe "#add_index_on_all_partitions" do
+    subject { adapter.add_index_on_all_partitions(:table_name, [:columns], unique: true, in_threads: 2) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:add_index_on_all_partitions)
+                             .with(:table_name, [:columns], unique: true, in_threads: 2)
       subject
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -43,4 +43,43 @@ RSpec.describe PgParty::Config do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#create_template_tables" do
+    subject { instance.create_template_tables }
+
+    context "when defaulted" do
+      it { is_expected.to eq(true) }
+    end
+
+    context "when overridden" do
+      before { instance.create_template_tables = false }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#create_with_primary_key" do
+    subject { instance.create_with_primary_key }
+
+    context "when defaulted" do
+      it { is_expected.to eq(false) }
+    end
+
+    context "when overridden" do
+      before { instance.create_with_primary_key = true }
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#include_subpartitions_in_partition_list" do
+    subject { instance.include_subpartitions_in_partition_list }
+
+    context "when defaulted" do
+      it { is_expected.to eq(false) }
+    end
+
+    context "when overridden" do
+      before { instance.include_subpartitions_in_partition_list = true }
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/spec/dummy/app/models/bigint_int_list_date_range_subpartition.rb
+++ b/spec/dummy/app/models/bigint_int_list_date_range_subpartition.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class BigintIntListDateRangeSubpartition < ApplicationRecord
+  list_partition_by :id
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -116,6 +116,29 @@ ActiveRecord::Schema.define do
     name: :bigint_custom_id_int_lists_b,
     values: [3, 4]
 
+  create_list_partition :bigint_int_list_date_range_subpartitions, primary_key: false, partition_key: [:id] do |t|
+    t.integer :id
+    t.timestamps null: false, precision: nil
+  end
+
+  create_list_partition_of \
+    :bigint_int_list_date_range_subpartitions,
+    name: :bigint_int_list_date_range_subpartitions_a,
+    values: [1, 2],
+    partition_type: :range,
+    partition_key: :created_at
+
+  create_range_partition_of \
+    :bigint_int_list_date_range_subpartitions_a,
+    name: :bigint_int_list_date_range_subpartitions_a_1,
+    start_range: Time.now - 1.day,
+    end_range: Time.now + 10.days
+
+  create_list_partition_of \
+    :bigint_int_list_date_range_subpartitions,
+    name: :bigint_int_list_date_range_subpartitions_b,
+    values: [3, 4]
+
   create_list_partition :uuid_string_lists, id: :uuid, partition_key: :some_string do |t|
     t.text :some_string, null: false
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -116,8 +116,7 @@ ActiveRecord::Schema.define do
     name: :bigint_custom_id_int_lists_b,
     values: [3, 4]
 
-  create_list_partition :bigint_int_list_date_range_subpartitions, primary_key: false, partition_key: [:id] do |t|
-    t.integer :id
+  create_list_partition :bigint_int_list_date_range_subpartitions, partition_key: :id do |t|
     t.timestamps null: false, precision: nil
   end
 

--- a/spec/integration/migration_postgres_10_spec.rb
+++ b/spec/integration/migration_postgres_10_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Integration tests run only on Postgres 10
+RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, if: PgVersionHelper.postgres_10? do
+  let(:table_name) { "t_#{SecureRandom.hex(6)}" }
+  let(:child_table_name) { "t_#{SecureRandom.hex(6)}" }
+  let(:table_like_name) { "t_#{SecureRandom.hex(6)}" }
+
+  before do
+    ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
+  end
+
+  after do
+    ActiveRecord::Base.primary_key_prefix_type = nil
+
+    adapter.execute("DROP TABLE IF EXISTS #{table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{child_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{table_like_name} CASCADE")
+  end
+
+  subject(:adapter) { ActiveRecord::Base.connection }
+
+  subject(:create_hash_partition) do
+    adapter.create_hash_partition(
+      table_name,
+      partition_key: "#{table_name}_id",
+      id: :serial
+    )
+  end
+
+  subject(:create_default_partition_of) do
+    adapter.create_default_partition_of(table_name)
+  end
+
+  describe "#create_hash_partition" do
+    subject { create_hash_partition }
+
+    it 'raises error' do
+      expect { subject }.to raise_error NotImplementedError,
+                                        'Hash partitions are only available in Postgres 11 or higher'
+    end
+  end
+
+  describe "#create_default_partition_of" do
+    subject { create_default_partition_of }
+
+    it 'raises error' do
+      expect { subject }.to raise_error NotImplementedError,
+                                        'Default partitions are only available in Postgres 11 or higher'
+    end
+  end
+end

--- a/spec/integration/migration_postgres_11_plus_spec.rb
+++ b/spec/integration/migration_postgres_11_plus_spec.rb
@@ -1,0 +1,473 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Integration tests run only on Postgres 11 and higher
+RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, if: PgVersionHelper.postgres_11_plus? do
+  let(:table_name) { "t1_#{SecureRandom.hex(6)}" }
+  let(:child_table_name) { "t2_#{SecureRandom.hex(6)}" }
+  let(:sibling_table_name) { "t3_#{SecureRandom.hex(6)}" }
+  let(:grandchild_table_name) { "t4_#{SecureRandom.hex(6)}" }
+  let(:table_like_name) { "t_#{SecureRandom.hex(6)}" }
+  let(:template_table_name) { "#{table_name}_template" }
+  let(:current_date) { Date.current }
+  let(:start_range) { current_date }
+  let(:end_range) { current_date + 1.month }
+  let(:index_prefix) { "i_#{SecureRandom.hex(6)}" }
+  let(:uuid_values) { [SecureRandom.uuid, SecureRandom.uuid] }
+  let(:create_with_primary_key) { false }
+
+  before do
+    ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
+  end
+
+  after do
+    ActiveRecord::Base.primary_key_prefix_type = nil
+
+    adapter.execute("DROP TABLE IF EXISTS #{table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{child_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{sibling_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{grandchild_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{table_like_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{template_table_name} CASCADE")
+  end
+
+  subject(:adapter) { ActiveRecord::Base.connection }
+
+  subject(:create_hash_partition) do
+    adapter.create_hash_partition(
+      table_name,
+      partition_key: "#{table_name}_id",
+      create_with_primary_key: create_with_primary_key,
+      id: :serial
+    ) do |t|
+      t.timestamps null: false, precision: nil
+    end
+  end
+
+  subject(:create_hash_partition_of) do
+    create_hash_partition
+
+    adapter.create_hash_partition_of(
+      table_name,
+      name: child_table_name,
+      modulus: 2,
+      remainder: 0
+    )
+  end
+
+  subject(:create_default_partition_of) do
+    create_hash_partition
+
+    adapter.create_default_partition_of(
+      table_name,
+      name: child_table_name
+    )
+  end
+
+  subject(:create_hash_table_like) do
+    create_hash_partition_of
+
+    adapter.create_table_like(child_table_name, table_like_name)
+  end
+
+  subject(:attach_hash_partition) do
+    create_hash_partition
+
+    adapter.execute("CREATE TABLE #{child_table_name} (LIKE #{table_name})")
+
+    adapter.attach_hash_partition(
+      table_name,
+      child_table_name,
+      modulus: 2,
+      remainder: 1
+    )
+  end
+
+  subject(:attach_default_partition) do
+    adapter.create_list_partition(
+      table_name,
+      partition_key: "#{table_name}_id",
+      id: :serial
+    )
+
+    adapter.execute("CREATE TABLE #{child_table_name} (LIKE #{table_name})")
+
+    adapter.attach_default_partition(
+      table_name,
+      child_table_name
+    )
+  end
+
+  subject(:create_range_partition_of_subpartitioned_by_list) do
+    adapter.create_range_partition(
+      table_name,
+      partition_key: ->{ "(created_at::date)" },
+      primary_key: :custom_id,
+      id: :uuid
+    ) do |t|
+      t.timestamps null: false, precision: nil
+    end
+
+    adapter.create_range_partition_of(
+      table_name,
+      name: child_table_name,
+      primary_key: :custom_id,
+      start_range: start_range,
+      end_range: end_range,
+      partition_type: :list,
+      partition_key: :custom_id
+    )
+
+    adapter.create_list_partition_of(
+      child_table_name,
+      name: grandchild_table_name,
+      values: uuid_values
+    )
+
+    adapter.create_range_partition_of(
+      table_name,
+      name: sibling_table_name,
+      primary_key: :custom_id,
+      start_range: end_range,
+      end_range: end_range + 1.month
+    )
+  end
+
+  subject(:add_index_on_all_partitions) do
+    create_range_partition_of_subpartitioned_by_list
+
+    adapter.add_index_on_all_partitions table_name, :updated_at, name: index_prefix, using: :hash,
+                                        algorithm: :concurrently,
+                                        where: "created_at > '#{current_date.to_time.iso8601}'"
+  end
+
+  describe "#create_hash_partition" do
+    let(:create_table_sql) do
+      <<-SQL
+        CREATE TABLE #{table_name} (
+          #{table_name}_id integer NOT NULL,
+          created_at timestamp without time zone NOT NULL,
+          updated_at timestamp without time zone NOT NULL
+        ) PARTITION BY HASH (#{table_name}_id);
+      SQL
+    end
+
+    let(:incrementing_id_sql) do
+      <<-SQL
+        ALTER TABLE ONLY #{table_name}
+        ALTER COLUMN #{table_name}_id
+        SET DEFAULT nextval('#{table_name}_#{table_name}_id_seq'::regclass);
+      SQL
+    end
+
+    let(:primary_key_sql) do
+      <<-SQL
+          ALTER TABLE ONLY #{table_name}
+          ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (#{table_name}_id);
+      SQL
+    end
+
+    subject do
+      create_hash_partition
+      PgDumpHelper.dump_table_structure(table_name)
+    end
+
+    it { is_expected.to include_heredoc(create_table_sql) }
+    it { is_expected.to include_heredoc(incrementing_id_sql) }
+    it { is_expected.not_to include_heredoc(primary_key_sql) }
+
+    describe "template table" do
+      let(:create_table_sql) do
+        <<-SQL
+          CREATE TABLE #{template_table_name} (
+            #{table_name}_id integer DEFAULT nextval('#{table_name}_#{table_name}_id_seq'::regclass) NOT NULL,
+            created_at timestamp without time zone NOT NULL,
+            updated_at timestamp without time zone NOT NULL
+          );
+        SQL
+      end
+
+      let(:primary_key_sql) do
+        <<-SQL
+          ALTER TABLE ONLY #{template_table_name}
+          ADD CONSTRAINT #{template_table_name}_pkey PRIMARY KEY (#{table_name}_id);
+        SQL
+      end
+
+      subject do
+        create_hash_partition
+        PgDumpHelper.dump_table_structure(template_table_name)
+      end
+
+      it { is_expected.to include_heredoc(create_table_sql) }
+      it { is_expected.to include_heredoc(primary_key_sql) }
+
+      context 'when config.create_template_tables = false' do
+        before { PgParty.config.create_template_tables = false }
+        after { PgParty.config.create_template_tables = true }
+
+        it { is_expected.not_to include_heredoc(create_table_sql) }
+        it { is_expected.not_to include_heredoc(primary_key_sql) }
+      end
+    end
+
+    context 'when config.create_with_primary_key = true' do
+      before { PgParty.config.create_with_primary_key = true }
+      after { PgParty.config.create_with_primary_key = false }
+
+      context 'when create_with_primary_key: false argument is provided' do
+        it { is_expected.to include_heredoc(create_table_sql) }
+        it { is_expected.to include_heredoc(incrementing_id_sql) }
+        it { is_expected.not_to include_heredoc(primary_key_sql) }
+      end
+
+      context 'when create_with_primary_key: argument is not provided' do
+        subject do
+          adapter.create_hash_partition(
+            table_name,
+            partition_key: "#{table_name}_id",
+            id: :serial
+          ) do |t|
+            t.timestamps null: false, precision: nil
+          end
+
+          PgDumpHelper.dump_table_structure(table_name)
+        end
+
+        it { is_expected.to include_heredoc(create_table_sql) }
+        it { is_expected.to include_heredoc(incrementing_id_sql) }
+        it { is_expected.to include_heredoc(primary_key_sql) }
+      end
+    end
+
+    context 'when create_with_primary_key: true argument is provided' do
+      let(:create_with_primary_key) { true }
+
+      it { is_expected.to include_heredoc(create_table_sql) }
+      it { is_expected.to include_heredoc(incrementing_id_sql) }
+      it { is_expected.to include_heredoc(primary_key_sql) }
+    end
+  end
+
+  describe '#create_hash_partition_of' do
+    let(:create_table_sql) do
+      <<-SQL
+        CREATE TABLE #{child_table_name} (
+          #{table_name}_id integer DEFAULT
+          nextval('#{table_name}_#{table_name}_id_seq'::regclass) NOT NULL,
+          created_at timestamp without time zone NOT NULL,
+          updated_at timestamp without time zone NOT NULL
+        );
+      SQL
+    end
+
+    let(:attach_table_sql) do
+      <<-SQL
+        ALTER TABLE ONLY #{table_name}
+        ATTACH PARTITION #{child_table_name}
+        FOR VALUES WITH (modulus 2, remainder 0);
+      SQL
+    end
+
+    let(:primary_key_sql) do
+      <<-SQL
+        ALTER TABLE ONLY #{child_table_name}
+        ADD CONSTRAINT #{child_table_name}_pkey
+        PRIMARY KEY (#{table_name}_id);
+      SQL
+    end
+
+    subject do
+      create_hash_partition_of
+      PgDumpHelper.dump_table_structure(child_table_name)
+    end
+
+    it { is_expected.to include_heredoc(create_table_sql) }
+    it { is_expected.to include_heredoc(attach_table_sql) }
+    it { is_expected.to include_heredoc(primary_key_sql) }
+
+    context 'when config.create_with_primary_key = true' do
+      before { PgParty.config.create_with_primary_key = true }
+      after { PgParty.config.create_with_primary_key = false }
+
+      it { is_expected.to include_heredoc(create_table_sql) }
+      it { is_expected.to include_heredoc(attach_table_sql) }
+      it { is_expected.to include_heredoc(primary_key_sql) }
+
+      context 'when config.create_template_tables = false' do
+        before { PgParty.config.create_template_tables = false }
+        after { PgParty.config.create_template_tables = true }
+
+        it { is_expected.to include_heredoc(create_table_sql) }
+        it { is_expected.to include_heredoc(attach_table_sql) }
+        it { is_expected.to include_heredoc(primary_key_sql) }
+      end
+    end
+  end
+
+  describe "#create_table_like" do
+    context "hash partition" do
+      let(:create_table_sql) do
+        <<-SQL
+          CREATE TABLE #{table_like_name} (
+            #{table_name}_id integer DEFAULT nextval('#{table_name}_#{table_name}_id_seq'::regclass) NOT NULL,
+            created_at timestamp without time zone NOT NULL,
+            updated_at timestamp without time zone NOT NULL
+          );
+        SQL
+      end
+
+      let(:primary_key_sql) do
+        <<-SQL
+          ALTER TABLE ONLY #{table_like_name}
+          ADD CONSTRAINT #{table_like_name}_pkey
+          PRIMARY KEY (#{table_name}_id);
+        SQL
+      end
+
+      subject do
+        create_hash_table_like
+        PgDumpHelper.dump_table_structure(table_like_name)
+      end
+
+      it { is_expected.to include_heredoc(create_table_sql) }
+      it { is_expected.to include_heredoc(primary_key_sql) }
+    end
+  end
+
+  describe "#attach_hash_partition" do
+    let(:attach_table_sql) do
+      <<-SQL
+        ALTER TABLE ONLY #{table_name}
+        ATTACH PARTITION #{child_table_name}
+        FOR VALUES WITH (modulus 2, remainder 1);
+      SQL
+    end
+
+    subject do
+      attach_hash_partition
+      PgDumpHelper.dump_table_structure(child_table_name)
+    end
+
+    it { is_expected.to include_heredoc(attach_table_sql) }
+  end
+
+  describe "#attach_default_partition" do
+    let(:attach_table_sql) do
+      <<-SQL
+        ALTER TABLE ONLY #{table_name}
+        ATTACH PARTITION #{child_table_name}
+        DEFAULT;
+      SQL
+    end
+
+    subject do
+      attach_default_partition
+      PgDumpHelper.dump_table_structure(child_table_name)
+    end
+
+    it { is_expected.to include_heredoc(attach_table_sql) }
+  end
+
+  describe "#add_index_on_all_partitions" do
+    let(:grandchild_index_sql) do
+      <<-SQL
+        CREATE INDEX #{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}
+        ON #{grandchild_table_name} USING hash (updated_at)
+        WHERE (created_at > '#{current_date} 00:00:00'::timestamp without time zone)
+      SQL
+    end
+    let(:sibling_index_sql) do
+      <<-SQL
+        CREATE INDEX #{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}
+        ON #{sibling_table_name} USING hash (updated_at)
+        WHERE (created_at > '#{current_date} 00:00:00'::timestamp without time zone)
+      SQL
+    end
+
+    before { allow(adapter).to receive(:execute).and_call_original }
+
+    subject do
+      add_index_on_all_partitions
+      PgDumpHelper.dump_indices
+    end
+
+    it { is_expected.to include_heredoc(sibling_index_sql) }
+    it { is_expected.to include_heredoc(grandchild_index_sql) }
+
+    it 'creates the indices using CONCURRENTLY directive because `algorthim: :concurrently` args are present' do
+      subject
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX CONCURRENTLY \"#{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}\" "\
+        "ON \"#{grandchild_table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX CONCURRENTLY \"#{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}\" "\
+        "ON \"#{sibling_table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+    end
+
+    it 'creates indices, non-concurrently, on partitioned tables using ON ONLY directive' do
+      subject
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX \"#{index_prefix}\" "\
+        "ON ONLY \"#{table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX \"#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}\" "\
+        "ON ONLY \"#{child_table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+    end
+
+    it 'attaches the partitioned indices to the correct parent table indices' do
+      subject
+      expect(adapter).to have_received(:execute).with(
+        "ALTER INDEX \"#{index_prefix}\" ATTACH PARTITION "\
+        "\"#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}\""
+      )
+      expect(adapter).to have_received(:execute).with(
+        "ALTER INDEX \"#{index_prefix}\" ATTACH PARTITION "\
+        "\"#{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}\""
+      )
+      expect(adapter).to have_received(:execute).with(
+        "ALTER INDEX \"#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}\" ATTACH PARTITION "\
+        "\"#{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}\""
+      )
+    end
+
+    context 'when an index is not valid at the end of the operation' do
+      let(:index_dump) { PgDumpHelper.dump_indices }
+
+      before do
+        # Simulate failure to attach a child index
+        allow(adapter).to receive(:execute).with(
+          "ALTER INDEX \"#{index_prefix}\" ATTACH PARTITION "\
+          "\"#{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}\""
+        )
+      end
+
+      it 'raises error, after dropping any indices created in the operation' do
+        expect { add_index_on_all_partitions }.to raise_error 'index creation failed - an index was marked invalid'
+        expect(index_dump).not_to include_heredoc(sibling_index_sql)
+        expect(index_dump).not_to include_heredoc(grandchild_index_sql)
+        expect(adapter).to have_received(:execute).with(
+          %[DROP INDEX IF EXISTS "#{index_prefix}"]
+        )
+        expect(adapter).to have_received(:execute).with(
+          %[DROP INDEX IF EXISTS "#{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}"]
+        )
+        expect(adapter).to have_received(:execute).with(
+          %[DROP INDEX IF EXISTS "#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}"]
+        )
+        expect(adapter).to have_received(:execute).with(
+          %[DROP INDEX IF EXISTS "#{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}"]
+        )
+      end
+    end
+  end
+end

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -502,9 +502,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
   describe '#parent_for_table_name' do
     let(:traverse) { false }
 
-    before do
-      create_range_partition_of_subpartitioned_by_list
-    end
+    before { create_range_partition_of_subpartitioned_by_list }
 
     it 'fetches the parent of the given table' do
       expect(adapter.parent_for_table_name(grandchild_table_name)).to eq child_table_name
@@ -620,6 +618,17 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
           end
         end
       end
+    end
+  end
+
+  describe '#table_partitioned?' do
+    before { create_range_partition_of_subpartitioned_by_list }
+
+    it 'returns true for partitioned tables; false for partitions themselves' do
+      expect(adapter.table_partitioned?(table_name)).to be true
+      expect(adapter.table_partitioned?(child_table_name)).to be true
+      expect(adapter.table_partitioned?(sibling_table_name)).to be false
+      expect(adapter.table_partitioned?(grandchild_table_name)).to be false
     end
   end
 end

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -2,16 +2,22 @@
 
 require "spec_helper"
 
+# These specs run on all Postgres versions
 RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
   let(:table_name) { "t_#{SecureRandom.hex(6)}" }
   let(:child_table_name) { "t_#{SecureRandom.hex(6)}" }
+  let(:sibling_table_name) { "t_#{SecureRandom.hex(6)}" }
+  let(:grandchild_table_name) { "t_#{SecureRandom.hex(6)}" }
   let(:table_like_name) { "t_#{SecureRandom.hex(6)}" }
   let(:template_table_name) { "#{table_name}_template" }
   let(:current_date) { Date.current }
   let(:start_range) { current_date }
   let(:end_range) { current_date + 1.month }
   let(:values) { (1..3) }
+  let(:uuid_values) { [SecureRandom.uuid, SecureRandom.uuid] }
   let(:timestamps_block) { ->(t) { t.timestamps null: false, precision: nil } }
+  let(:index_prefix) { "i_#{SecureRandom.hex(6)}" }
+  let(:index_threads) { nil }
   let(:uuid_function) do
     if Rails.gem_version >= Gem::Version.new("5.1")
       "gen_random_uuid()"
@@ -29,7 +35,10 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
 
     adapter.execute("DROP TABLE IF EXISTS #{table_name} CASCADE")
     adapter.execute("DROP TABLE IF EXISTS #{child_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{sibling_table_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{grandchild_table_name} CASCADE")
     adapter.execute("DROP TABLE IF EXISTS #{table_like_name} CASCADE")
+    adapter.execute("DROP TABLE IF EXISTS #{template_table_name} CASCADE")
   end
 
   subject(:adapter) { ActiveRecord::Base.connection }
@@ -62,6 +71,40 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
       primary_key: :custom_id,
       start_range: start_range,
       end_range: end_range
+    )
+  end
+
+  subject(:create_range_partition_of_subpartitioned_by_list) do
+    adapter.create_range_partition(
+      table_name,
+      partition_key: ->{ "(created_at::date)" },
+      primary_key: :custom_id,
+      id: :uuid,
+      &timestamps_block
+    )
+
+    adapter.create_range_partition_of(
+      table_name,
+      name: child_table_name,
+      primary_key: :custom_id,
+      start_range: start_range,
+      end_range: end_range,
+      partition_type: :list,
+      partition_key: :custom_id
+    )
+
+    adapter.create_list_partition_of(
+      child_table_name,
+      name: grandchild_table_name,
+      values: uuid_values
+    )
+
+    adapter.create_range_partition_of(
+      table_name,
+      name: sibling_table_name,
+      primary_key: :custom_id,
+      start_range: end_range,
+      end_range: end_range + 1.month
     )
   end
 
@@ -117,6 +160,14 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
     create_range_partition_of
 
     adapter.detach_partition(table_name, child_table_name)
+  end
+
+  subject(:add_index_on_all_partitions) do
+    create_range_partition_of_subpartitioned_by_list
+
+    adapter.add_index_on_all_partitions table_name, :updated_at, name: index_prefix, using: :hash,
+                                        in_threads: index_threads, algorithm: :concurrently,
+                                        where: "created_at > '#{current_date.to_time.iso8601}'"
   end
 
   describe "#create_range_partition" do
@@ -196,6 +247,14 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
 
       it { is_expected.to include_heredoc(create_table_sql) }
       it { is_expected.to include_heredoc(primary_key_sql) }
+
+      context 'when config.create_template_tables = false' do
+        before { PgParty.config.create_template_tables = false }
+        after { PgParty.config.create_template_tables = true }
+
+        it { is_expected.not_to include_heredoc(create_table_sql) }
+        it { is_expected.not_to include_heredoc(primary_key_sql) }
+      end
     end
   end
 
@@ -234,6 +293,65 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
     it { is_expected.to include_heredoc(create_table_sql) }
     it { is_expected.to include_heredoc(attach_table_sql) }
     it { is_expected.to include_heredoc(primary_key_sql) }
+
+    context 'when subpartitioning' do
+      let(:create_table_sql) do
+        <<-SQL
+          CREATE TABLE #{child_table_name} (
+            custom_id uuid DEFAULT #{uuid_function} NOT NULL,
+            created_at timestamp without time zone NOT NULL,
+            updated_at timestamp without time zone NOT NULL
+          )
+          PARTITION BY LIST (custom_id);
+        SQL
+      end
+
+      subject do
+        create_range_partition_of_subpartitioned_by_list
+        PgDumpHelper.dump_table_structure(child_table_name)
+      end
+
+      it { is_expected.to include_heredoc(create_table_sql) }
+      it { is_expected.to include_heredoc(attach_table_sql) }
+      it { is_expected.not_to include_heredoc(primary_key_sql) }
+    end
+
+    context 'when an unsupported partition_type: is specified' do
+      subject(:create_range_partition_of) do
+        create_range_partition
+
+        adapter.create_range_partition_of(
+          table_name,
+          name: child_table_name,
+          partition_type: :something_invalid,
+          partition_key: :custom_id,
+          start_range: start_range,
+          end_range: end_range,
+        )
+      end
+
+      it 'raises ArgumentError' do
+        expect { subject }.to raise_error ArgumentError, 'Supported partition types are range, list, hash'
+      end
+    end
+
+    context 'when partition_type: is specified but not partition_key:' do
+      subject(:create_range_partition_of) do
+        create_range_partition
+
+        adapter.create_range_partition_of(
+          table_name,
+          name: child_table_name,
+          partition_type: :list,
+          start_range: start_range,
+          end_range: end_range,
+        )
+      end
+
+      it 'raises ArgumentError' do
+        expect { subject }.to raise_error ArgumentError, '`partition_key` is required when specifying a partition_type'
+      end
+    end
   end
 
   describe "#create_list_partition_of" do
@@ -379,5 +497,129 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
 
     it { is_expected.to include_heredoc(create_table_sql) }
     it { is_expected.to_not include("ATTACH") }
+  end
+
+  describe '#parent_for_table_name' do
+    let(:traverse) { false }
+
+    before do
+      create_range_partition_of_subpartitioned_by_list
+    end
+
+    it 'fetches the parent of the given table' do
+      expect(adapter.parent_for_table_name(grandchild_table_name)).to eq child_table_name
+      expect(adapter.parent_for_table_name(child_table_name)).to eq table_name
+      expect(adapter.parent_for_table_name(table_name)).to be_nil
+    end
+
+    context 'when traverse: true argument is specified' do
+      it 'returns top-level ancestor' do
+        expect(adapter.parent_for_table_name(grandchild_table_name, traverse: true)).to eq table_name
+        expect(adapter.parent_for_table_name(child_table_name, traverse: true)).to eq table_name
+        expect(adapter.parent_for_table_name(table_name, traverse: true)).to be_nil
+      end
+    end
+  end
+
+  describe '#partitions_for_table_name' do
+    let(:traverse) { false }
+
+    before do
+      create_range_partition_of_subpartitioned_by_list
+    end
+
+    context 'when include_subpartitions: false' do
+      it 'fetches the partitions of the table specified' do
+        expect(adapter.partitions_for_table_name(table_name, include_subpartitions: false)).to eq(
+          [child_table_name, sibling_table_name]
+        )
+        expect(adapter.partitions_for_table_name(child_table_name, include_subpartitions: false)).to eq(
+          [grandchild_table_name]
+        )
+        expect(adapter.partitions_for_table_name(grandchild_table_name, include_subpartitions: false)).to be_empty
+      end
+    end
+
+    context 'when include_subpartitions: true' do
+      it 'fetches all partitions and subpartitions of the table specified' do
+        expect(adapter.partitions_for_table_name(table_name, include_subpartitions: true)).to eq(
+          [child_table_name, grandchild_table_name, sibling_table_name]
+        )
+        expect(adapter.partitions_for_table_name(child_table_name, include_subpartitions: true)).to eq(
+          [grandchild_table_name]
+        )
+        expect(adapter.partitions_for_table_name(grandchild_table_name, include_subpartitions: true)).to be_empty
+      end
+    end
+  end
+
+  describe "#add_index_on_all_partitions" do
+    let(:grandchild_index_sql) do
+      <<-SQL
+        CREATE INDEX #{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}
+        ON #{grandchild_table_name} USING hash (updated_at)
+        WHERE (created_at > '#{current_date} 00:00:00'::timestamp without time zone)
+      SQL
+    end
+    let(:sibling_index_sql) do
+      <<-SQL
+        CREATE INDEX #{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}
+        ON #{sibling_table_name} USING hash (updated_at)
+        WHERE (created_at > '#{current_date} 00:00:00'::timestamp without time zone)
+      SQL
+    end
+
+    before { allow(adapter).to receive(:execute).and_call_original }
+
+    subject do
+      add_index_on_all_partitions
+      PgDumpHelper.dump_indices
+    end
+
+    it { is_expected.to include_heredoc(sibling_index_sql) }
+    it { is_expected.to include_heredoc(grandchild_index_sql) }
+
+    it 'creates the indices using CONCURRENTLY directive because `algorthim: :concurrently` args are present' do
+      subject
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX CONCURRENTLY \"#{index_prefix}_#{Digest::MD5.hexdigest(grandchild_table_name)[0..6]}\" "\
+        "ON \"#{grandchild_table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+      expect(adapter).to have_received(:execute).with(
+        "CREATE  INDEX CONCURRENTLY \"#{index_prefix}_#{Digest::MD5.hexdigest(sibling_table_name)[0..6]}\" "\
+        "ON \"#{sibling_table_name}\" USING hash (\"updated_at\") "\
+        "WHERE created_at > '#{current_date.to_time.iso8601}'"
+      )
+    end
+
+    context 'when in_threads: is provided' do
+      let(:index_threads) { 2 }
+
+      before do
+        allow(Parallel).to receive(:map).with([child_table_name, sibling_table_name], in_threads: index_threads)
+                             .and_yield(child_table_name).and_yield(sibling_table_name)
+      end
+
+      it 'calls through Parallel.map' do
+        subject
+        expect(Parallel).to have_received(:map)
+                              .with([child_table_name, sibling_table_name], in_threads: index_threads)
+      end
+
+      it { is_expected.to include_heredoc(sibling_index_sql) }
+      it { is_expected.to include_heredoc(grandchild_index_sql) }
+
+      context 'when in a transaction' do
+        it 'raises ArgumentError' do
+          ActiveRecord::Base.transaction do
+            expect { subject }.to raise_error(ArgumentError,
+              '`in_threads:` cannot be used within a transaction. If running in a migration, use '\
+              '`disable_ddl_transaction!` and break out this operation into its own migration.'
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/integration/model/bigint_int_list_date_range_subpartition_spec.rb
+++ b/spec/integration/model/bigint_int_list_date_range_subpartition_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe BigintIntListDateRangeSubpartition do
+  let(:current_date) { Date.current }
+  let(:current_time) { Time.current }
+  let(:connection) { described_class.connection }
+  let(:schema_cache) { connection.schema_cache }
+  let(:table_name) { described_class.table_name }
+
+  describe ".primary_key" do
+    subject { described_class.primary_key }
+
+    it { is_expected.to eq("id") }
+  end
+
+  describe ".create" do
+    let(:created_at) { current_time }
+    let(:id) { 1 }
+
+    subject { described_class.create!(id: id, created_at: created_at) }
+
+    context "when partition key in list" do
+      its(:id) { is_expected.to be_a(Integer) }
+      its(:id) { is_expected.to eq(id) }
+      its(:created_at) { is_expected.to eq(created_at) }
+    end
+
+    context "when partition key outside list" do
+      let(:id) { 5 }
+
+      it "raises error" do
+        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+      end
+    end
+
+    context "when subpartition key outside range" do
+      let(:created_at) { current_time - 10.days }
+
+      it "raises error" do
+        expect { subject }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+      end
+    end
+  end
+
+  describe ".partitions" do
+    subject { described_class.partitions }
+
+    context "when query successful" do
+      it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_b") }
+    end
+
+    context "when an error occurs" do
+      before { allow(PgParty.cache).to receive(:fetch_partitions).and_raise("boom") }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'include_subpartitions: true' do
+      subject { described_class.partitions(include_subpartitions: true) }
+
+      it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_a_1", "#{table_name}_b") }
+    end
+
+    context 'config.include_subpartitions_in_partition_list = true' do
+      before { PgParty.config.include_subpartitions_in_partition_list = true }
+      after { PgParty.config.include_subpartitions_in_partition_list = false }
+
+      it { is_expected.to contain_exactly("#{table_name}_a", "#{table_name}_a_1", "#{table_name}_b") }
+    end
+  end
+end

--- a/spec/model/hash_methods_spec.rb
+++ b/spec/model/hash_methods_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe PgParty::Model::ListMethods do
+RSpec.describe PgParty::Model::HashMethods do
   let(:decorator) { instance_double(PgParty::ModelDecorator) }
 
   before do
@@ -11,14 +11,15 @@ RSpec.describe PgParty::Model::ListMethods do
 
   subject(:model) do
     Class.new do
-      extend PgParty::Model::ListMethods
+      extend PgParty::Model::HashMethods
     end
   end
 
   describe ".create_partition" do
     let(:args) do
       {
-        values: Date.current,
+        modulus: 2,
+        remainder: 0,
         name: "my_partition"
       }
     end
@@ -26,32 +27,18 @@ RSpec.describe PgParty::Model::ListMethods do
     subject { model.create_partition(args) }
 
     it "delegates to decorator" do
-      expect(decorator).to receive(:create_list_partition).with(args)
-      subject
-    end
-  end
-
-  describe ".create_default_partition" do
-    let(:args) do
-      {
-        name: "my_partition"
-      }
-    end
-    subject { model.create_default_partition(args) }
-
-    it "delegates to decorator" do
-      expect(decorator).to receive(:create_default_partition).with(args)
+      expect(decorator).to receive(:create_hash_partition).with(args)
       subject
     end
   end
 
   describe ".partition_key_in" do
-    let(:values) { [Date.current, Date.tomorrow] }
+    let(:values) { [2, SecureRandom.uuid] }
 
     subject { model.partition_key_in(values) }
 
     it "delegates to decorator" do
-      expect(decorator).to receive(:list_partition_key_in).with(values)
+      expect(decorator).to receive(:hash_partition_key_in).with(values)
       subject
     end
   end

--- a/spec/model/methods_spec.rb
+++ b/spec/model/methods_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PgParty::Model::Methods do
     allow(PgParty::ModelInjector).to receive(:new).and_return(injector)
     allow(injector).to receive(:inject_range_methods)
     allow(injector).to receive(:inject_list_methods)
+    allow(injector).to receive(:inject_hash_methods)
   end
 
   describe ".range_partition_by" do
@@ -87,6 +88,43 @@ RSpec.describe PgParty::Model::Methods do
 
       it "delegates to injector" do
         expect(injector).to receive(:inject_list_methods)
+        subject
+      end
+    end
+  end
+
+  describe ".hash_partition_by" do
+    context "when partition key provided as argument" do
+      subject { model.hash_partition_by(key) }
+
+      it "initializes injector with model and key" do
+        expect(PgParty::ModelInjector).to receive(:new).with(model, key)
+        subject
+      end
+
+      it "delegates to injector" do
+        expect(injector).to receive(:inject_hash_methods)
+        subject
+      end
+    end
+
+    context "when partition key provided as block" do
+      let(:key_as_block) { ->{ key } }
+
+      subject { model.hash_partition_by(&key_as_block) }
+
+      it "initializes injector with model and block" do
+        expect(PgParty::ModelInjector).to receive(:new) do |m, &blk|
+          expect(m).to eq(model)
+          expect(blk).to eq(blk)
+          injector
+        end
+
+        subject
+      end
+
+      it "delegates to injector" do
+        expect(injector).to receive(:inject_hash_methods)
         subject
       end
     end

--- a/spec/model/range_methods_spec.rb
+++ b/spec/model/range_methods_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe PgParty::Model::RangeMethods do
     end
   end
 
+  describe ".create_default_partition" do
+    let(:args) do
+      {
+        name: "my_partition"
+      }
+    end
+    subject { model.create_default_partition(args) }
+
+    it "delegates to decorator" do
+      expect(decorator).to receive(:create_default_partition).with(args)
+      subject
+    end
+  end
+
   describe ".partition_key_in" do
     let(:start_range) { Date.current }
     let(:end_range)   { Date.tomorrow }

--- a/spec/model/shared_methods_spec.rb
+++ b/spec/model/shared_methods_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe PgParty::Model::SharedMethods do
   end
 
   describe ".partitions" do
-    subject { model.partitions }
+    subject { model.partitions(include_subpartitions: true) }
 
     it "delegates to decorator" do
-      expect(decorator).to receive(:partitions)
+      expect(decorator).to receive(:partitions).with(include_subpartitions: true)
       subject
     end
   end

--- a/spec/model_injector_spec.rb
+++ b/spec/model_injector_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe PgParty::ModelInjector do
 
   subject(:inject_range_methods) { injector.inject_range_methods }
   subject(:inject_list_methods) { injector.inject_list_methods }
+  subject(:inject_hash_methods) { injector.inject_hash_methods }
 
   before { allow(model).to receive(:extend).and_call_original }
 
@@ -116,7 +117,7 @@ RSpec.describe PgParty::ModelInjector do
     context "when key is array" do
       let(:key) { ["created_at", "updated_at"] }
 
-      it "extends range methods" do
+      it "extends list methods" do
         expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
         subject
       end
@@ -142,7 +143,7 @@ RSpec.describe PgParty::ModelInjector do
 
       let(:injector) { described_class.new(model, &blk) }
 
-      it "extends range methods" do
+      it "extends list methods" do
         expect(model).to receive(:extend).with(PgParty::Model::ListMethods)
         subject
       end
@@ -155,6 +156,82 @@ RSpec.describe PgParty::ModelInjector do
       describe "model" do
         subject do
           inject_list_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at::date") }
+        its(:complex_partition_key) { is_expected.to eq(true) }
+      end
+    end
+  end
+
+  describe "#inject_hash_methods" do
+    subject { inject_hash_methods }
+
+    context "when key is a string" do
+      it "extends hash methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::HashMethods)
+        subject
+      end
+
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_hash_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq("created_at") }
+        its(:complex_partition_key) { is_expected.to eq(false) }
+      end
+    end
+
+    context "when key is array" do
+      let(:key) { ["created_at", "updated_at"] }
+
+      it "extends hash methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::HashMethods)
+        subject
+      end
+
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_hash_methods
+          model
+        end
+
+        its(:partition_key) { is_expected.to eq(["created_at", "updated_at"]) }
+        its(:complex_partition_key) { is_expected.to eq(false) }
+      end
+    end
+
+    context "when block is provided" do
+      let(:blk) { ->{ "created_at::date" } }
+
+      let(:injector) { described_class.new(model, &blk) }
+
+      it "extends hash methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::HashMethods)
+        subject
+      end
+
+      it "extends shared methods" do
+        expect(model).to receive(:extend).with(PgParty::Model::SharedMethods)
+        subject
+      end
+
+      describe "model" do
+        subject do
+          inject_hash_methods
           model
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ end
 require "pg_party/model/shared_methods"
 require "pg_party/model/range_methods"
 require "pg_party/model/list_methods"
+require "pg_party/model/hash_methods"
 
 Combustion.path = "spec/dummy"
 Combustion.initialize! :active_record do
@@ -34,6 +35,7 @@ require "database_cleaner"
 require "support/uuid_matcher"
 require "support/heredoc_matcher"
 require "support/pg_dump_helper"
+require "support/pg_version_helper"
 
 static_time = Date.current + 12.hours
 

--- a/spec/support/pg_dump_helper.rb
+++ b/spec/support/pg_dump_helper.rb
@@ -9,6 +9,12 @@ class PgDumpHelper
     pg_dump.gsub("#{schema_name}.", "")
   end
 
+  def self.dump_indices
+    ActiveRecord::Base.connection.select_values(
+      "SELECT indexdef FROM pg_indexes WHERE tablename NOT LIKE 'pg%'"
+    ).join('; ').gsub("#{schema_name}.", "")
+  end
+
   private
 
   def initialize(options)
@@ -28,11 +34,19 @@ class PgDumpHelper
     env_strings.join(" ")
   end
 
-  def config
+  def self.config
     @config ||= ActiveRecord::Base.connection_config
   end
 
-  def schema_name
+  def config
+    self.class.config
+  end
+
+  def self.schema_name
     config[:schema_search_path]
+  end
+
+  def schema_name
+    self.class.schema_name
   end
 end

--- a/spec/support/pg_version_helper.rb
+++ b/spec/support/pg_version_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PgVersionHelper
+  def self.postgres_10?
+    version >= 100000 && version < 110000
+  end
+
+  def self.postgres_11_plus?
+    version >= 110000
+  end
+
+  def self.version
+    @version ||= ActiveRecord::Base.connection.postgresql_version
+  end
+end


### PR DESCRIPTION
Thank you for this fantastic gem! I have incorporated this gem into a new project and made a good number of enhancements I'd like to contribute back to the project. I have ensured full backward compatibility to avoid a major version bump.

I've added `CHANGES.md`, as I think it could be useful if you were up for keeping it updated. Here's the summary for this PR:

## 1.4.0 - Postgres 11+ feature support and enhancements
#### Full Postgres 11 feature support has been added with complete backward compatibility
* When starting a fresh project with Postgres 11 or higher, you can disable template tables and enable primary key constraints on partitioned tables:
    * `config.create_template_tables` now governs whether template tables are created by default (defaults true).
    * `config.create_with_primary_key` passed down primary key options to CREATE TABLE, including support for composite primary keys
* `create_hash_partition`, `create_hash_partition_of`, and `attach_hash_partition` methods provide support for Hash partitions
* `create_default_partition_of` and `attach_default_partition` allows adding of default partitions to range and list partitioned tables
#### Full support for Subpartitioning
* `create_x_partition_of` methods now support `partition_type` and `partition_key`, which may be supplied to create
  a partitioned child table.
    * Use `create_x_partition_of` with the child table name to add a partition to your subpartition
    * Template tables are supported in that nested subpartitions will inherit from the top-level ancestor's template table, if found
* The `partitions` command now accepts an `include_subpartitions:` option which defaults to false for backward compatibility
    * Use `config.include_subpartitions_in_partition_list = true` to override the default
#### `add_index_on_all_partitions`
* Use this new adapter method in migrations to add an index on all partitions and subpartitions automatically
* This method supports `algorithm: :concurrently` to perform uptime operations, so even when using Postgres 11+ it is needed to avoid table locks.
* If you have many partitions, use the optional `in_threads:` option to parallelize index creation via the `parallel` gem
#### Minor enhancements
* Added adapter methods `partitions_for_table_name`, `parent_for_table_name`, and `table_partitioned?` to assist automating partition management, especially where subpartitions are involved