### PR TITLE
Restore backward compatibility for include_subpartitions

### DIFF
--- a/lib/pg_party/model/shared_methods.rb
+++ b/lib/pg_party/model/shared_methods.rb
@@ -8,7 +8,7 @@ module PgParty
       def reset_primary_key
         return base_class.primary_key if self != base_class
 
-        partitions = partitions(include_subpartitions: true)
+        partitions = partitions(include_subpartitions: PgParty.config.include_subpartitions_in_partition_list)
         return get_primary_key(base_class.name) if partitions.empty?
 
         first_partition = partitions.detect { |p| !connection.table_partitioned?(p) }

--- a/spec/model/shared_methods_spec.rb
+++ b/spec/model/shared_methods_spec.rb
@@ -12,6 +12,34 @@ RSpec.describe PgParty::Model::SharedMethods do
   subject(:model) do
     Class.new do
       extend PgParty::Model::SharedMethods
+
+      def self.base_class
+        self
+      end
+
+      def self.get_primary_key(class_name)
+        nil
+      end
+    end
+  end
+
+  describe ".reset_primary_key" do
+    subject { model.reset_primary_key }
+
+    context 'when using default config: config.include_subpartitions_in_partition_list = false' do
+      it do
+        expect(decorator).to receive(:partitions).with(include_subpartitions: false).and_return([])
+        subject
+      end
+    end
+
+    context 'config.include_subpartitions_in_partition_list = true' do
+      before { PgParty.config.include_subpartitions_in_partition_list = true }
+
+      it do
+        expect(decorator).to receive(:partitions).with(include_subpartitions: true).and_return([])
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
The current version (1.4) is not using the configuration option `include_subpartitions_in_partition_list` to avoid including nested subpartitions. So, it is not completely backward compatible with the previous version. This causes unnecessary queries on partition tables in search of subpartitions.