### PR TITLE
Keep migrations consistent after Rails upgrades

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -200,7 +200,7 @@ module PgParty
       end
       modified_options[:options] = partition_by_clause(type, partition_key)
 
-      migration_or_adapter(blk).public_send(:create_table, table_name, **modified_options) do |td|
+      migration_or_adapter(blk).create_table(table_name, **modified_options) do |td|
         if !modified_options[:id] && id == :uuid
           td.column(primary_key, id, null: false, default: uuid_function)
         elsif !modified_options[:id] && id
@@ -211,7 +211,7 @@ module PgParty
       end
 
       # Rails 4 has a bug where uuid columns are always nullable
-      migration_or_adapter(blk).public_send(:change_column_null, table_name, primary_key, false) if !modified_options[:id] && id == :uuid
+      migration_or_adapter(blk).change_column_null(table_name, primary_key, false) if !modified_options[:id] && id == :uuid
 
       return unless template
 

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -200,7 +200,7 @@ module PgParty
       end
       modified_options[:options] = partition_by_clause(type, partition_key)
 
-      (blk&.binding&.receiver || self).public_send(:create_table, table_name, **modified_options) do |td|
+      migration_or_adapter(blk).public_send(:create_table, table_name, **modified_options) do |td|
         if !modified_options[:id] && id == :uuid
           td.column(primary_key, id, null: false, default: uuid_function)
         elsif !modified_options[:id] && id
@@ -211,7 +211,7 @@ module PgParty
       end
 
       # Rails 4 has a bug where uuid columns are always nullable
-      (blk&.binding&.receiver || self).public_send(:change_column_null, table_name, primary_key, false) if !modified_options[:id] && id == :uuid
+      migration_or_adapter(blk).public_send(:change_column_null, table_name, primary_key, false) if !modified_options[:id] && id == :uuid
 
       return unless template
 
@@ -454,6 +454,11 @@ module PgParty
 
     def postgres_major_version
       __getobj__.send(:postgresql_version)/10000
+    end
+
+    def migration_or_adapter(blk)
+      blk_receiver = blk&.binding&.receiver
+      blk_receiver.is_a?(ActiveRecord::Migration) ? blk_receiver : self
     end
   end
 end


### PR DESCRIPTION
We recently upgraded a project from Rails v6.1 to v7.0, which [changed the default precision for datetime columns from `nil` to `6`](https://github.com/rails/rails/pull/42297). PgParty currently calls [`ActiveRecord::ConnectionAdapters::SchemaStatements#create_table`](https://github.com/rkrage/pg_party/blob/f24ef5849d0c616ba905855a30909b0b28dc13e3/lib/pg_party/adapter_decorator.rb#L203) (and [`#change_column_null`](https://github.com/rkrage/pg_party/blob/f24ef5849d0c616ba905855a30909b0b28dc13e3/lib/pg_party/adapter_decorator.rb#L214)) directly, which doesn't include the backwards compatibility provided by [`ActiveRecord::Migration::Compatibility`](https://api.rubyonrails.org/v7.0.3.1/classes/ActiveRecord/Migration/Compatibility.html). Thus, re-running our existing migrations generated those datetime columns with `precision: 6` instead of `precision: nil`.

This change uses [`Proc#binding`](https://ruby-doc.org/core-2.7.0/Proc.html#method-i-binding)/[`Binding#receiver`](https://ruby-doc.org/core-2.7.0/Binding.html#method-i-receiver) to call those methods on the `ActiveRecord::Migration` instance instead, which includes that backwards compatibility.

Thank you!