### PR TITLE
Correctly handle partitioned tables in schemas other then public

### DIFF
--- a/lib/pg_party/hacks/postgresql_database_tasks.rb
+++ b/lib/pg_party/hacks/postgresql_database_tasks.rb
@@ -10,13 +10,20 @@ module PgParty
 
         partitions = begin
           ActiveRecord::Base.connection.select_values(
-            "SELECT DISTINCT inhrelid::regclass::text FROM pg_inherits"
+            """
+              SELECT
+                inhrelid::regclass::text
+              FROM
+                pg_inherits
+              JOIN pg_class AS p ON inhparent = p.oid
+              WHERE p.relkind = 'p'
+            """
           )
         rescue
           []
         end
 
-        excluded_tables = partitions.flat_map { |table| ["-T", "*.#{table}"] }
+        excluded_tables = partitions.flat_map { |table| ["-T", table] }
 
         super(cmd, args + excluded_tables, action)
       end


### PR DESCRIPTION
This PR clothes #70.

First of all new query excludes from query results all objects other then tables. Also there is no reason to prefix them with `*.` as tables are returned with schema names.