### PR TITLE
Exclude only inherited tables from pg_dump

### DIFF
--- a/lib/pg_party/hacks/postgresql_database_tasks.rb
+++ b/lib/pg_party/hacks/postgresql_database_tasks.rb
@@ -9,16 +9,14 @@ module PgParty
         end
 
         partitions = begin
-          ActiveRecord::Base.connection.select_values(
-            """
-              SELECT
-                inhrelid::regclass::text
-              FROM
-                pg_inherits
-              JOIN pg_class AS p ON inhparent = p.oid
-              WHERE p.relkind = 'p'
-            """
-          )
+          ActiveRecord::Base.connection.select_values(<<-SQL)
+            SELECT
+              inhrelid::regclass::text
+            FROM
+              pg_inherits
+            JOIN pg_class AS p ON inhparent = p.oid
+            WHERE p.relkind = 'p'
+          SQL
         rescue
           []
         end

--- a/lib/pg_party/hacks/postgresql_database_tasks.rb
+++ b/lib/pg_party/hacks/postgresql_database_tasks.rb
@@ -10,7 +10,14 @@ module PgParty
 
         partitions = begin
           ActiveRecord::Base.connection.select_values(
-            "SELECT DISTINCT inhrelid::regclass::text FROM pg_inherits"
+            """
+              SELECT
+                inhrelid::regclass::text
+              FROM
+                pg_inherits
+              JOIN pg_class AS p ON inhparent = p.oid
+              WHERE p.relkind = 'p'
+            """
           )
         rescue
           []


### PR DESCRIPTION
The existing query returns inherited tables, primary key and indexes. Here is the result for a database that has inherited partitioned table `time_tracking.entries_y2022_12`:

- `time_tracking.entries_y2022_m12_date_idx`
- `time_tracking.entries_y2022_m12_company_id_member_id_task_uuid_idx`
- `time_tracking.entries_y2022_m12_pkey`
- `time_tracking.entries_y2022_m12`

This is not needed since we only need tables to be excluded with `-T` option for `pg_dump`. The new query uses `pg_class` system catalog, which allows filtering only tables from other inherited objects. Below is a result for the same data structure as above.

- `time_tracking.entries_y2022_m12` 

