### PR TITLE
Name schema discovery queries

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -117,7 +117,7 @@ module PgParty
             ON pg_tables.tablename::regclass = pg_inherits.inhparent::regclass
           WHERE pg_tables.schemaname = current_schema() AND
           pg_tables.tablename = #{quote(table_name)}
-                    ]).each_with_object(_accumulator) do |partition, acc|
+                    ], "SCHEMA").each_with_object(_accumulator) do |partition, acc|
         acc << partition
         next unless include_subpartitions
 
@@ -133,7 +133,7 @@ module PgParty
             ON pg_tables.tablename::regclass = pg_inherits.inhrelid::regclass
           WHERE pg_tables.schemaname = current_schema() AND
           pg_tables.tablename = #{quote(table_name)}
-      ]).first
+      ], "SCHEMA").first
       return parent if parent.nil? || !traverse
 
       while (parents_parent = parent_for_table_name(parent)) do
@@ -174,7 +174,7 @@ module PgParty
         SELECT relkind FROM pg_catalog.pg_class AS c
         JOIN pg_catalog.pg_namespace AS ns ON c.relnamespace = ns.oid
         WHERE relname = #{quote(table_name)} AND nspname = current_schema()
-      ]).first == 'p'
+      ], "SCHEMA").first == 'p'
     end
 
     private
@@ -420,7 +420,8 @@ module PgParty
     def index_valid?(index_name)
       select_values(
         "SELECT relname FROM pg_class, pg_index WHERE pg_index.indisvalid = false AND "\
-          "pg_index.indexrelid = pg_class.oid AND relname = #{quote(index_name)}"
+          "pg_index.indexrelid = pg_class.oid AND relname = #{quote(index_name)}",
+        "SCHEMA"
       ).empty?
     end
 

--- a/lib/pg_party/hacks/postgresql_database_tasks.rb
+++ b/lib/pg_party/hacks/postgresql_database_tasks.rb
@@ -8,7 +8,7 @@ module PgParty
           return super
         end
 
-        partitions = ActiveRecord::Base.connection.select_values(<<-SQL)
+        partitions = ActiveRecord::Base.connection.select_values(<<-SQL, "SCHEMA")
           SELECT
             inhrelid::regclass::text
           FROM


### PR DESCRIPTION
Active Record allows naming queries for observability purposes. For schema discovery queries, Active Record uses the "SCHEMA" name.

This allows subscribers of the `sql.active_record` event to special case schema discovery queries. For instance, Active Record's [log subscriber][1] ignore those queries.

Naming PgParty's schema discovery queries means those queries can be more easily identified and processed as such.

[1]: https://github.com/rails/rails/blob/v7.0.4.3/activerecord/lib/active_record/log_subscriber.rb