### PR TITLE
Drop `ruby2_keywords` dependency

### DIFF
--- a/lib/pg_party/adapter/postgresql_methods.rb
+++ b/lib/pg_party/adapter/postgresql_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pg_party/adapter_decorator"
-require "ruby2_keywords"
 
 module PgParty
   module Adapter

--- a/lib/pg_party/model/hash_methods.rb
+++ b/lib/pg_party/model/hash_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pg_party/model_decorator"
-require "ruby2_keywords"
 
 module PgParty
   module Model

--- a/lib/pg_party/model/list_methods.rb
+++ b/lib/pg_party/model/list_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pg_party/model_decorator"
-require "ruby2_keywords"
 
 module PgParty
   module Model

--- a/lib/pg_party/model/range_methods.rb
+++ b/lib/pg_party/model/range_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pg_party/model_decorator"
-require "ruby2_keywords"
 
 module PgParty
   module Model

--- a/pg_party.gemspec
+++ b/pg_party.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activerecord", ">= 6.1", "< 7.2"
-  spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
   spec.add_runtime_dependency "parallel", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
Since Ruby 2.7, these methods are defined by default. Currently this gem requires Ruby 3.0 so it can be safely removed.