### PR TITLE
Check all schemas in search_path, not just the topmost one.

### DIFF
--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -115,7 +115,7 @@ module PgParty
           FROM pg_tables
           INNER JOIN pg_inherits
             ON pg_tables.tablename::regclass = pg_inherits.inhparent::regclass
-          WHERE pg_tables.schemaname = current_schema() AND
+          WHERE pg_tables.schemaname = ANY(current_schemas(false)) AND
           pg_tables.tablename = #{quote(table_name)}
                     ], "SCHEMA").each_with_object(_accumulator) do |partition, acc|
         acc << partition
@@ -131,7 +131,7 @@ module PgParty
           FROM pg_tables
           INNER JOIN pg_inherits
             ON pg_tables.tablename::regclass = pg_inherits.inhrelid::regclass
-          WHERE pg_tables.schemaname = current_schema() AND
+          WHERE pg_tables.schemaname = ANY(current_schemas(false)) AND
           pg_tables.tablename = #{quote(table_name)}
       ], "SCHEMA").first
       return parent if parent.nil? || !traverse
@@ -173,7 +173,7 @@ module PgParty
       select_values(%[
         SELECT relkind FROM pg_catalog.pg_class AS c
         JOIN pg_catalog.pg_namespace AS ns ON c.relnamespace = ns.oid
-        WHERE relname = #{quote(table_name)} AND nspname = current_schema()
+        WHERE relname = #{quote(table_name)} AND nspname = ANY(current_schemas(false))
       ], "SCHEMA").first == 'p'
     end
 


### PR DESCRIPTION
The previous version of this code implicitly assumed that the topmost schema in the search_path (usually '`public`') is the only one that needs to be searched. This leads to issues with multi-schema deployments.

Postgres has a built-in function to check all
entries in the search_path (see
https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION), `current_schemas(include_implicit boolean)`, and this is what we are using to solve this issue.