### PR TITLE
Support `if_not_exists` on add_index_on_all_partitions

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,7 @@
 
 ENV["RAILS_ENV"] ||= "development"
 
+require "logger"
 require "bundler/setup"
 require "combustion"
 

--- a/pg_party.gemspec
+++ b/pg_party.gemspec
@@ -27,6 +27,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "byebug", "~> 11.0"
+  spec.add_development_dependency "base64", "~> 0.2.0"
+  spec.add_development_dependency "bigdecimal", "~> 3.1"
+  spec.add_development_dependency "mutex_m", "~> 0.3.0"
+  spec.add_development_dependency "drb", "~> 2.2"
   spec.add_development_dependency "combustion", "~> 1.3"
   spec.add_development_dependency "nokogiri", ">= 1.10.4", "< 2.0"
   spec.add_development_dependency "pry-byebug", "~> 3.7"

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -648,6 +648,28 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
       )
     end
 
+    context 'when an error occurs while creating the index' do
+      subject(:add_index_on_all_partitions) do
+        create_list_partition_of
+
+        adapter.add_index_on_all_partitions table_name, "#{table_name}_id", name: index_prefix,
+                                            in_threads: index_threads, algorithm: :concurrently
+      end
+
+      let(:index_name) { "#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}" }
+      let(:create_index_query) do
+        "CREATE  INDEX CONCURRENTLY \"#{index_name}\" " \
+          "ON \"#{child_table_name}\"  (\"#{table_name}_id\")"
+      end
+      let(:query_error) { ActiveRecord::StatementInvalid }
+
+      it 'deletes the created indexes' do
+        expect(adapter).to receive(:execute).with(create_index_query).and_raise(query_error)
+        expect(adapter).to receive(:execute).with("DROP INDEX IF EXISTS \"#{index_name}\"")
+        expect { subject }.to raise_error(query_error)
+      end
+    end
+
     context 'when unique: true index option is used' do
       subject(:add_index_on_all_partitions) do
         create_list_partition_of
@@ -662,6 +684,33 @@ RSpec.describe ActiveRecord::ConnectionAdapters::PostgreSQLAdapter do
           "CREATE UNIQUE INDEX CONCURRENTLY \"#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}\" "\
           "ON \"#{child_table_name}\"  (\"#{table_name}_id\")"
         )
+      end
+    end
+
+    context 'when if_not_exists: true index option is used' do
+      subject(:add_index_on_all_partitions) do
+        create_list_partition_of
+
+        adapter.add_index_on_all_partitions table_name, "#{table_name}_id", name: index_prefix,
+                                            in_threads: index_threads, algorithm: :concurrently, if_not_exists: true
+      end
+
+      let(:index_name) { "#{index_prefix}_#{Digest::MD5.hexdigest(child_table_name)[0..6]}" }
+      let(:create_index_query) do
+        "CREATE  INDEX CONCURRENTLY IF NOT EXISTS \"#{index_name}\" " \
+          "ON \"#{child_table_name}\"  (\"#{table_name}_id\")"
+      end
+      let(:query_error) { ActiveRecord::StatementInvalid }
+
+      it 'creates an index if it does not exist already' do
+        subject
+        expect(adapter).to have_received(:execute).with(create_index_query)
+      end
+
+      it 'keeps indexes on error' do
+        expect(adapter).to receive(:execute).with(create_index_query).and_raise(query_error)
+        expect(adapter).not_to receive(:execute).with("DROP INDEX IF EXISTS \"#{index_name}\"")
+        expect { subject }.to raise_error(query_error)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
+require "logger"
 require "combustion"
 require "timecop"
 require "pry-byebug"


### PR DESCRIPTION
Hi @rkrage , thanks for maintaining this gem. It really makes using partitioning a breeze 🥇 

This PR adds support for the `if_not_exists: true` option when using `add_index_on_all_partitions`, similar to what Rails provides on `add_index`. The `if_not_exists` gets cascaded to the sub-tables, meaning that the whole operation can be resumed where it was left off in the event of an error, timeout etc.

## Rationale
We're in a situation where we need to run long-running migrations in background jobs, which also means we need to deal with job timeouts. And because we have a fair amount of data, those timeouts are expected (since the `concurrently` option is synchronous from a connection perspective). Restarting a migration from scratch on error or timeout is not a viable option.

The `if_not_exists` approach, combined with the `concurrently` option, gives us the ability to have resilient migration jobs that resume themselves and create indexes progressively.

We already use this approach with regular tables, and it would be great to have the same with partitioned tables 🚀 